### PR TITLE
feat: add card layout and mobile photo upload

### DIFF
--- a/gptgig/src/app/services/photo.service.ts
+++ b/gptgig/src/app/services/photo.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { Camera, CameraResultType, CameraSource, Photo } from '@capacitor/camera';
 import { Filesystem, Directory } from '@capacitor/filesystem';
 import { Preferences } from '@capacitor/preferences';
+import { Capacitor } from '@capacitor/core';
 import { Platform } from '@ionic/angular';
 
 @Injectable({ providedIn: 'root' })
@@ -10,6 +11,17 @@ public photos: UserPhoto[] = [];
   private PHOTO_STORAGE: string = 'photos';
 
   constructor(private platform: Platform) {}
+
+  async captureBase64(): Promise<string | undefined> {
+    const photo = await Camera.getPhoto({
+      resultType: CameraResultType.Base64,
+      source: CameraSource.Camera,
+      quality: 90,
+    });
+    return photo.base64String
+      ? `data:image/${photo.format};base64,${photo.base64String}`
+      : undefined;
+  }
 
   public async loadSaved() {
     // Retrieve cached photo array data
@@ -86,7 +98,7 @@ public photos: UserPhoto[] = [];
       // already loaded into memory
       return {
         filepath: fileName,
-        webviewPath: photo.webPath,
+        webviewPath: photo.webPath!,
       };
     }
   }
@@ -97,7 +109,7 @@ public photos: UserPhoto[] = [];
     if (this.platform.is('hybrid')) {
       // Read the file into base64 format
       const file = await Filesystem.readFile({
-        path: photo.path,
+        path: photo.path!,
       });
 
       return file.data;

--- a/gptgig/src/app/tabs/pages/admin/admin.page.html
+++ b/gptgig/src/app/tabs/pages/admin/admin.page.html
@@ -5,65 +5,94 @@
 </ion-header>
 
 <ion-content class="admin">
-  <ion-list inset="true">
-    <ion-item-divider color="primary"><ion-label>Service Categories</ion-label></ion-item-divider>
-    <form [formGroup]="catForm" (ngSubmit)="onCatSubmit()">
-      <ion-item>
-        <ion-input formControlName="name" label="Name" labelPlacement="floating" required></ion-input>
-      </ion-item>
-      <ion-item>
-        <ion-input formControlName="icon" label="Icon (ionicon name)" labelPlacement="stacked"></ion-input>
-      </ion-item>
-      <ion-button type="submit" expand="block">Save Category</ion-button>
-    </form>
+  <ion-card>
+    <ion-card-header>
+      <ion-card-title>Service Categories</ion-card-title>
+    </ion-card-header>
+    <ion-card-content>
+      <form [formGroup]="catForm" (ngSubmit)="onCatSubmit()">
+        <ion-item>
+          <ion-input formControlName="name" label="Name" labelPlacement="floating" required></ion-input>
+        </ion-item>
+        <ion-item>
+          <ion-input formControlName="icon" label="Icon (ionicon name)" labelPlacement="stacked"></ion-input>
+        </ion-item>
+        <ion-button type="submit" expand="block">Save Category</ion-button>
+      </form>
+    </ion-card-content>
+  </ion-card>
 
-    <ion-item-divider color="primary"><ion-label>Services (Rect Cards)</ion-label></ion-item-divider>
-    <form [formGroup]="svcForm" (ngSubmit)="onSvcSubmit()">
-      <ion-item>
-        <ion-input formControlName="title" label="Title" labelPlacement="floating" required></ion-input>
-      </ion-item>
-      <ion-item>
-        <ion-select formControlName="categoryId" label="Category" labelPlacement="stacked" interface="popover">
-          <ion-select-option *ngFor="let c of (categories$ | async)" [value]="c.id">{{c.name}}</ion-select-option>
-        </ion-select>
-      </ion-item>
-      <ion-item>
-        <ion-input type="number" formControlName="price" label="Price (USD)" labelPlacement="stacked"></ion-input>
-      </ion-item>
-      <ion-item>
-        <ion-input type="number" formControlName="durationMin" label="Duration (min)" labelPlacement="stacked"></ion-input>
-      </ion-item>
-      <ion-item lines="none">
-        <ion-label>Image</ion-label>
-        <input type="file" accept="image/*" (change)="handleImage($event, 'imageUrl')" />
-      </ion-item>
-      <ion-button type="submit" expand="block">Save Service</ion-button>
-    </form>
+  <ion-card>
+    <ion-card-header>
+      <ion-card-title>Services (Rect Cards)</ion-card-title>
+    </ion-card-header>
+    <ion-card-content>
+      <form [formGroup]="svcForm" (ngSubmit)="onSvcSubmit()">
+        <ion-item>
+          <ion-input formControlName="title" label="Title" labelPlacement="floating" required></ion-input>
+        </ion-item>
+        <ion-item>
+          <ion-select formControlName="categoryId" label="Category" labelPlacement="stacked" interface="popover">
+            <ion-select-option *ngFor="let c of (categories$ | async)" [value]="c.id">{{c.name}}</ion-select-option>
+          </ion-select>
+        </ion-item>
+        <ion-item>
+          <ion-input type="number" formControlName="price" label="Price (USD)" labelPlacement="stacked"></ion-input>
+        </ion-item>
+        <ion-item>
+          <ion-input type="number" formControlName="durationMin" label="Duration (min)" labelPlacement="stacked"></ion-input>
+        </ion-item>
+        <ion-item lines="none" *ngIf="!isMobile">
+          <ion-label>Image</ion-label>
+          <input type="file" accept="image/*" (change)="handleFile($event, 'imageUrl')" />
+        </ion-item>
+        <ion-item lines="none" *ngIf="isMobile">
+          <ion-label>Image</ion-label>
+          <ion-button (click)="captureImage('imageUrl')">Take Photo</ion-button>
+        </ion-item>
+        <ion-button type="submit" expand="block">Save Service</ion-button>
+      </form>
+    </ion-card-content>
+  </ion-card>
 
-    <ion-item-divider color="primary"><ion-label>Providers (Circular Cards)</ion-label></ion-item-divider>
-    <form [formGroup]="providerForm" (ngSubmit)="onProvSubmit()">
-      <ion-item>
-        <ion-input formControlName="name" label="Name" labelPlacement="floating" required></ion-input>
-      </ion-item>
-      <ion-item>
-        <ion-input type="number" formControlName="rating" label="Rating" labelPlacement="stacked"></ion-input>
-      </ion-item>
-      <ion-item lines="none">
-        <ion-label>Avatar</ion-label>
-        <input type="file" accept="image/*" (change)="handleImage($event, 'avatarUrl')" />
-      </ion-item>
-      <ion-button type="submit" expand="block">Save Provider</ion-button>
-    </form>
-  </ion-list>
+  <ion-card>
+    <ion-card-header>
+      <ion-card-title>Providers (Circular Cards)</ion-card-title>
+    </ion-card-header>
+    <ion-card-content>
+      <form [formGroup]="providerForm" (ngSubmit)="onProvSubmit()">
+        <ion-item>
+          <ion-input formControlName="name" label="Name" labelPlacement="floating" required></ion-input>
+        </ion-item>
+        <ion-item>
+          <ion-input type="number" formControlName="rating" label="Rating" labelPlacement="stacked"></ion-input>
+        </ion-item>
+        <ion-item lines="none" *ngIf="!isMobile">
+          <ion-label>Avatar</ion-label>
+          <input type="file" accept="image/*" (change)="handleFile($event, 'avatarUrl')" />
+        </ion-item>
+        <ion-item lines="none" *ngIf="isMobile">
+          <ion-label>Avatar</ion-label>
+          <ion-button (click)="captureImage('avatarUrl')">Take Photo</ion-button>
+        </ion-item>
+        <ion-button type="submit" expand="block">Save Provider</ion-button>
+      </form>
+    </ion-card-content>
+  </ion-card>
 
-  <ion-list inset="true">
-    <ion-item-divider><ion-label>Current Services</ion-label></ion-item-divider>
-    <ion-item *ngFor="let s of (services$ | async)">
-      <ion-thumbnail slot="start"><img [src]="s.imageUrl || 'assets/placeholder-rect.jpg'"></ion-thumbnail>
-      <ion-label>
-        <div>{{s.title}}</div>
-        <small>{{s.price ? ('$'+s.price) : ''}}</small>
-      </ion-label>
-    </ion-item>
-  </ion-list>
+  <ion-card>
+    <ion-card-header>
+      <ion-card-title>Current Services</ion-card-title>
+    </ion-card-header>
+    <ion-card-content>
+      <ion-item *ngFor="let s of (services$ | async)">
+        <ion-thumbnail slot="start"><img [src]="s.imageUrl || 'assets/placeholder-rect.jpg'"></ion-thumbnail>
+        <ion-label>
+          <div>{{s.title}}</div>
+          <small>{{s.price ? ('$'+s.price) : ''}}</small>
+        </ion-label>
+      </ion-item>
+    </ion-card-content>
+  </ion-card>
 </ion-content>
+

--- a/gptgig/src/app/tabs/pages/admin/admin.page.ts
+++ b/gptgig/src/app/tabs/pages/admin/admin.page.ts
@@ -1,8 +1,9 @@
 import { Component, inject } from '@angular/core';
-import { IonicModule, ToastController } from '@ionic/angular';
+import { IonicModule, ToastController, Platform } from '@ionic/angular';
 import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { CatalogService } from '../../../services/catalog.service';
+import { PhotoService } from '../../../services/photo.service';
 
 
 // Lightweight UUID (optional): if you prefer, replace with Date.now().toString()
@@ -18,6 +19,9 @@ export class AdminPage {
   private fb = inject(FormBuilder);
   private catalog = inject(CatalogService);
   private toast = inject(ToastController);
+  private platform = inject(Platform);
+  private photoSvc = inject(PhotoService);
+  isMobile = this.platform.is('hybrid');
 
   categories$ = this.catalog.categories$;
   services$   = this.catalog.services$;
@@ -69,10 +73,18 @@ export class AdminPage {
     this.toastMsg('Provider saved');
   }
 
-  async handleImage(event: Event, control: 'imageUrl' | 'avatarUrl') {
+  async handleFile(event: Event, control: 'imageUrl' | 'avatarUrl') {
     const input = event.target as HTMLInputElement;
     if (input.files?.length) {
       const base64 = await this.catalog.toBase64(input.files[0]);
+      if (control === 'imageUrl') this.svcForm.patchValue({ imageUrl: base64 });
+      if (control === 'avatarUrl') this.providerForm.patchValue({ avatarUrl: base64 });
+    }
+  }
+
+  async captureImage(control: 'imageUrl' | 'avatarUrl') {
+    const base64 = await this.photoSvc.captureBase64();
+    if (base64) {
       if (control === 'imageUrl') this.svcForm.patchValue({ imageUrl: base64 });
       if (control === 'avatarUrl') this.providerForm.patchValue({ avatarUrl: base64 });
     }


### PR DESCRIPTION
## Summary
- Wrap admin sections in Ion cards for clearer layout
- Add mobile photo capture using `PhotoService` when running on hybrid platforms
- Extend `PhotoService` with base64 capture support

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_b_689f4d10010883318b874a9a60824fbe