### PR TITLE
feat: brighten silver accent color

### DIFF
--- a/gptgig/src/theme/variables.scss
+++ b/gptgig/src/theme/variables.scss
@@ -3,7 +3,7 @@
 :root {
   /* Brand */
   --eagle-green: #004c54; /* Eagle Green (approx) */
-  --light-silver: #d8d8d8;
+  --light-silver: #eeeeee;
 
   /* Ionic color slots */
   --ion-color-primary: var(--eagle-green);
@@ -14,11 +14,11 @@
   --ion-color-primary-tint: #1a6067;
 
   --ion-color-secondary: var(--light-silver);
-  --ion-color-secondary-rgb: 216, 216, 216;
+  --ion-color-secondary-rgb: 238, 238, 238;
   --ion-color-secondary-contrast: #0a0a0a;
   --ion-color-secondary-contrast-rgb: 10, 10, 10;
-  --ion-color-secondary-shade: #bebebe;
-  --ion-color-secondary-tint: #e0e0e0;
+  --ion-color-secondary-shade: #d4d4d4;
+  --ion-color-secondary-tint: #f6f6f6;
 
   /* Light defaults */
   --ion-background-color: #ffffff;


### PR DESCRIPTION
## Summary
- brighten light silver accent color for better visibility

## Testing
- `npm run lint` (fails: Expected `!==` but received `!=` @angular-eslint/template/eqeqeq)
- `npm test -- --watch=false` (fails: No binary for Chrome browser on your platform)

------
https://chatgpt.com/codex/tasks/task_b_689f57ba0350833184ae625fa4195aaf