### PR TITLE
feat: add ionicon imports for tabs

### DIFF
--- a/gptgig/src/app/tabs/tabs.page.ts
+++ b/gptgig/src/app/tabs/tabs.page.ts
@@ -1,7 +1,7 @@
 import { Component, EnvironmentInjector, inject } from '@angular/core';
 import { IonTabs, IonTabBar, IonTabButton, IonIcon, IonLabel } from '@ionic/angular/standalone';
 import { addIcons } from 'ionicons';
-import { triangle, ellipse, square } from 'ionicons/icons';
+import { home, search, briefcase, mail, person } from 'ionicons/icons';
 
 @Component({
   selector: 'app-tabs',
@@ -13,6 +13,6 @@ export class TabsPage {
   public environmentInjector = inject(EnvironmentInjector);
 
   constructor() {
-    addIcons({ triangle, ellipse, square });
+    addIcons({ home, search, briefcase, mail, person });
   }
 }


### PR DESCRIPTION
## Summary
- add Ionicons for home, search, briefcase, mail, and person tabs

## Testing
- `npm test -- --watch=false` (fails: No binary for Chrome browser)
- `npm run lint` (fails: lint errors in unrelated files)


------
https://chatgpt.com/codex/tasks/task_b_689f60d58ca08331a48895bfc689204a