### PR TITLE
Add OpenAPI specification with version

### DIFF
--- a/gptgigapi/openapi.yaml
+++ b/gptgigapi/openapi.yaml
@@ -1,0 +1,11 @@
+openapi: 3.0.0
+info:
+  title: gptgigapi
+  version: "1.0.0"
+paths:
+  /WeatherForecast:
+    get:
+      summary: Get weather forecast
+      responses:
+        '200':
+          description: Successful response


### PR DESCRIPTION
## Summary
- add OpenAPI definition with `openapi` version field

## Testing
- `dotnet test gptgigapi/gptgigapi.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*
- `npm test` *(fails: ng test requires a browser and was terminated)*

------
https://chatgpt.com/codex/tasks/task_b_689f7914beac83319fe6690d49366110