### PR TITLE
feat: add basic cart page

### DIFF
--- a/gptgig/src/app/app.routes.ts
+++ b/gptgig/src/app/app.routes.ts
@@ -13,4 +13,8 @@ export const routes: Routes = [
     path: 'register',
     loadComponent: () => import('./auth/register.page').then((m) => m.RegisterPage),
   },
+  {
+    path: 'cart',
+    loadComponent: () => import('./cart/cart.page').then((m) => m.CartPage),
+  },
 ];

--- a/gptgig/src/app/cart/cart.page.html
+++ b/gptgig/src/app/cart/cart.page.html
@@ -1,0 +1,13 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Cart</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content>
+  <ion-list>
+    <ion-item>
+      <ion-label>Your cart is empty.</ion-label>
+    </ion-item>
+  </ion-list>
+</ion-content>

--- a/gptgig/src/app/cart/cart.page.scss
+++ b/gptgig/src/app/cart/cart.page.scss
@@ -1,0 +1,1 @@
+/* Empty for now */

--- a/gptgig/src/app/cart/cart.page.spec.ts
+++ b/gptgig/src/app/cart/cart.page.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CartPage } from './cart.page';
+
+describe('CartPage', () => {
+  let component: CartPage;
+  let fixture: ComponentFixture<CartPage>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CartPage],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CartPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/gptgig/src/app/cart/cart.page.ts
+++ b/gptgig/src/app/cart/cart.page.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IonicModule } from '@ionic/angular';
+
+@Component({
+  selector: 'app-cart',
+  standalone: true,
+  imports: [IonicModule, CommonModule],
+  templateUrl: './cart.page.html',
+  styleUrls: ['./cart.page.scss'],
+})
+export class CartPage {}


### PR DESCRIPTION
## Summary
- add standalone CartPage with placeholder view
- register cart route for app navigation

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_b_689f9b484ba08331ae987c451a93e665