### PR TITLE
Ensure JWT key meets HS256 requirements

### DIFF
--- a/gptgigapi/appsettings.Development.json
+++ b/gptgigapi/appsettings.Development.json
@@ -15,6 +15,6 @@
   "Jwt": {
     "Issuer": "gptgigapi",
     "Audience": "gptgigapi",
-    "Key": "CHANGE_ME_TO_A_STRONG_KEY"
+    "Key": "8dce5a97767304fad78f04e3e318e74f8e4c86fed88f363a541de1387e758cb5"
   }
 }

--- a/gptgigapi/appsettings.json
+++ b/gptgigapi/appsettings.json
@@ -16,6 +16,6 @@
   "Jwt": {
     "Issuer": "gptgigapi",
     "Audience": "gptgigapi",
-    "Key": "CHANGE_ME_TO_A_STRONG_KEY"
+    "Key": "8dce5a97767304fad78f04e3e318e74f8e4c86fed88f363a541de1387e758cb5"
   }
 }


### PR DESCRIPTION
## Summary
- replace short placeholder key with 256-bit secret in appsettings

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_b_689fb3bc56e083318a855830dd96ac0b