### PR TITLE
Add notification testing endpoint

### DIFF
--- a/gptgigapi/Controllers/NotificationController.cs
+++ b/gptgigapi/Controllers/NotificationController.cs
@@ -1,0 +1,34 @@
+using gptgigapi.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace gptgigapi.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class NotificationController : ControllerBase
+    {
+        private readonly INotificationService _notificationService;
+
+        public NotificationController(INotificationService notificationService)
+        {
+            _notificationService = notificationService;
+        }
+
+        [HttpPost("email")]
+        public async Task<IActionResult> SendEmail([FromBody] EmailDto dto)
+        {
+            await _notificationService.SendEmailAsync(dto.To, dto.Subject, dto.Body);
+            return Ok();
+        }
+
+        [HttpPost("sms")]
+        public async Task<IActionResult> SendSms([FromBody] SmsDto dto)
+        {
+            await _notificationService.SendSmsAsync(dto.PhoneNumber, dto.Message);
+            return Ok();
+        }
+    }
+
+    public record EmailDto(string To, string Subject, string Body);
+    public record SmsDto(string PhoneNumber, string Message);
+}


### PR DESCRIPTION
## Summary
- expose notification service via API for test emails and SMS

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_b_689fc1c843888331a7d3c621d1d2c328