### PR TITLE
feat: enable email and sms notifications

### DIFF
--- a/gptgigapi/Services/NotificationService.cs
+++ b/gptgigapi/Services/NotificationService.cs
@@ -1,27 +1,56 @@
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using System.Net;
+using System.Net.Mail;
 using System.Threading.Tasks;
+using Twilio;
+using Twilio.Rest.Api.V2010.Account;
+using Twilio.Types;
 
 namespace gptgigapi.Services
 {
     public class NotificationService : INotificationService
     {
         private readonly ILogger<NotificationService> _logger;
+        private readonly IConfiguration _configuration;
 
-        public NotificationService(ILogger<NotificationService> logger)
+        public NotificationService(ILogger<NotificationService> logger, IConfiguration configuration)
         {
             _logger = logger;
+            _configuration = configuration;
         }
 
-        public Task SendEmailAsync(string to, string subject, string body)
+        public async Task SendEmailAsync(string to, string subject, string body)
         {
-            _logger.LogInformation("Sending email to {To} with subject {Subject}", to, subject);
-            return Task.CompletedTask;
+            var host = _configuration["EmailSettings:SmtpHost"];
+            var port = int.TryParse(_configuration["EmailSettings:SmtpPort"], out var p) ? p : 587;
+            var username = _configuration["EmailSettings:Username"];
+            var password = _configuration["EmailSettings:Password"];
+            var from = _configuration["EmailSettings:From"];
+
+            using var client = new SmtpClient(host, port)
+            {
+                Credentials = new NetworkCredential(username, password),
+                EnableSsl = true
+            };
+
+            using var message = new MailMessage(from!, to, subject, body);
+            await client.SendMailAsync(message);
+            _logger.LogInformation("Email sent to {To} with subject {Subject}", to, subject);
         }
 
-        public Task SendSmsAsync(string phoneNumber, string message)
+        public async Task SendSmsAsync(string phoneNumber, string message)
         {
-            _logger.LogInformation("Sending SMS to {PhoneNumber}: {Message}", phoneNumber, message);
-            return Task.CompletedTask;
+            var accountSid = _configuration["Twilio:AccountSid"];
+            var authToken = _configuration["Twilio:AuthToken"];
+            var fromNumber = _configuration["Twilio:FromNumber"];
+
+            TwilioClient.Init(accountSid, authToken);
+            await MessageResource.CreateAsync(
+                to: new PhoneNumber(phoneNumber),
+                from: new PhoneNumber(fromNumber),
+                body: message);
+            _logger.LogInformation("SMS sent to {PhoneNumber}", phoneNumber);
         }
     }
 }

--- a/gptgigapi/appsettings.Development.json
+++ b/gptgigapi/appsettings.Development.json
@@ -16,5 +16,17 @@
     "Issuer": "gptgigapi",
     "Audience": "gptgigapi",
     "Key": "8dce5a97767304fad78f04e3e318e74f8e4c86fed88f363a541de1387e758cb5"
+  },
+  "EmailSettings": {
+    "SmtpHost": "smtp.example.com",
+    "SmtpPort": 587,
+    "Username": "user@example.com",
+    "Password": "password",
+    "From": "noreply@example.com"
+  },
+  "Twilio": {
+    "AccountSid": "your_account_sid",
+    "AuthToken": "your_auth_token",
+    "FromNumber": "+1234567890"
   }
 }

--- a/gptgigapi/appsettings.json
+++ b/gptgigapi/appsettings.json
@@ -17,5 +17,17 @@
     "Issuer": "gptgigapi",
     "Audience": "gptgigapi",
     "Key": "8dce5a97767304fad78f04e3e318e74f8e4c86fed88f363a541de1387e758cb5"
+  },
+  "EmailSettings": {
+    "SmtpHost": "smtp.example.com",
+    "SmtpPort": 587,
+    "Username": "user@example.com",
+    "Password": "password",
+    "From": "noreply@example.com"
+  },
+  "Twilio": {
+    "AccountSid": "your_account_sid",
+    "AuthToken": "your_auth_token",
+    "FromNumber": "+1234567890"
   }
 }

--- a/gptgigapi/gptgigapi.csproj
+++ b/gptgigapi/gptgigapi.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.8" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.25.0" />
+    <PackageReference Include="Twilio" Version="7.12.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- send emails through SMTP using configuration
- deliver SMS messages via Twilio
- add Twilio dependency and configuration sections for credentials

## Testing
- `dotnet build gptgigapi/gptgigapi.csproj`

------
https://chatgpt.com/codex/tasks/task_b_689fc934a68c8331b9fda7f83b2feb9c