### PR TITLE
Add JWT auth support to Swagger

### DIFF
--- a/gptgigapi/Program.cs
+++ b/gptgigapi/Program.cs
@@ -67,6 +67,31 @@ builder.Services.AddSwaggerGen(options =>
             Url = new Uri("https://example.com/license")
         }
     });
+
+    options.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
+    {
+        Name = "Authorization",
+        Type = SecuritySchemeType.Http,
+        Scheme = "bearer",
+        BearerFormat = "JWT",
+        In = ParameterLocation.Header,
+        Description = "JWT Authorization header using the Bearer scheme."
+    });
+
+    options.AddSecurityRequirement(new OpenApiSecurityRequirement
+    {
+        {
+            new OpenApiSecurityScheme
+            {
+                Reference = new OpenApiReference
+                {
+                    Type = ReferenceType.SecurityScheme,
+                    Id = "Bearer"
+                }
+            },
+            Array.Empty<string>()
+        }
+    });
 });
 var app = builder.Build();
 


### PR DESCRIPTION
## Summary
- enable JWT bearer authentication within Swagger configuration so clients can authorize requests

## Testing
- `dotnet build gptgigapi/gptgigapi.csproj`


------
https://chatgpt.com/codex/tasks/task_b_689fdf427d8083319a807f148ac1f7b6