### PR TITLE
feat: load catalog from api

### DIFF
--- a/gptgig/src/app/services/catalog.service.ts
+++ b/gptgig/src/app/services/catalog.service.ts
@@ -1,68 +1,49 @@
 import { Injectable } from '@angular/core';
-import { BehaviorSubject } from 'rxjs';
+import { BehaviorSubject, tap } from 'rxjs';
+import { HttpClient } from '@angular/common/http';
 import { ServiceCategory, ServiceItem, Provider } from '../models/catalog.models';
-
-const LS_KEY = 'lumorate-catalog-v1';
-
-interface CatalogState {
-  categories: ServiceCategory[];
-  services: ServiceItem[];
-  providers: Provider[];
-}
+import { environment } from '../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class CatalogService {
-  private state: CatalogState = this.load() ?? {
-    categories: [
-      { id: 'clean', name: 'Cleaning', icon: 'sparkles' },
-      { id: 'move',  name: 'Moving',   icon: 'cube' },
-      { id: 'tech',  name: 'Tech Help',icon: 'hardware-chip' },
-    ],
-    services: [
-      { id: 'svc1', title: 'Apartment Deep Clean', categoryId: 'clean', price: 149, durationMin: 180, imageUrl: 'assets/samples/clean1.jpg', rating: 4.9 },
-      { id: 'svc2', title: 'Two Movers & Truck', categoryId: 'move', price: 95, durationMin: 120, imageUrl: 'assets/samples/move1.jpg', rating: 4.7 },
-      { id: 'svc3', title: 'Home Wi‑Fi Tune Up', categoryId: 'tech', price: 79, durationMin: 60, imageUrl: 'assets/samples/tech1.jpg', rating: 4.8 },
-    ],
-    providers: [
-      { id: 'pro1', name: 'Avery J.', avatarUrl: 'assets/samples/p1.jpg', rating: 4.9, tags: ['Cleaning','Move-Out'] },
-      { id: 'pro2', name: 'Kai M.',   avatarUrl: 'assets/samples/p2.jpg', rating: 4.8, tags: ['Tech Help'] },
-      { id: 'pro3', name: 'Riley P.', avatarUrl: 'assets/samples/p3.jpg', rating: 4.7, tags: ['Moving'] },
-    ],
-  };
+  private baseUrl = `${environment.apiUrl}/catalog`;
 
-  categories$ = new BehaviorSubject<ServiceCategory[]>([...this.state.categories]);
-  services$   = new BehaviorSubject<ServiceItem[]>([...this.state.services]);
-  providers$  = new BehaviorSubject<Provider[]>([...this.state.providers]);
+  categories$ = new BehaviorSubject<ServiceCategory[]>([]);
+  services$   = new BehaviorSubject<ServiceItem[]>([]);
+  providers$  = new BehaviorSubject<Provider[]>([]);
 
-  private save() {
-    localStorage.setItem(LS_KEY, JSON.stringify(this.state));
+  constructor(private http: HttpClient) {
+    this.refresh();
   }
 
-  private load(): CatalogState | null {
-    const raw = localStorage.getItem(LS_KEY);
-    return raw ? JSON.parse(raw) as CatalogState : null;
-    // In a real app, swap to a backend API or Firebase.
+  /** Load catalog items from backend API */
+  refresh() {
+    this.http.get<ServiceCategory[]>(`${this.baseUrl}/categories`)
+      .subscribe(data => this.categories$.next(data));
+
+    this.http.get<ServiceItem[]>(`${this.baseUrl}/services`)
+      .subscribe(data => this.services$.next(data));
+
+    this.http.get<Provider[]>(`${this.baseUrl}/providers`)
+      .subscribe(data => this.providers$.next(data));
   }
 
+  /** Upsert category via backend */
   upsertCategory(cat: ServiceCategory) {
-    const idx = this.state.categories.findIndex(c => c.id === cat.id);
-    idx > -1 ? (this.state.categories[idx] = cat) : this.state.categories.push(cat);
-    this.categories$.next([...this.state.categories]);
-    this.save();
+    return this.http.post<ServiceCategory>(`${this.baseUrl}/categories`, cat)
+      .pipe(tap(() => this.refresh()));
   }
 
+  /** Upsert service via backend */
   upsertService(svc: ServiceItem) {
-    const idx = this.state.services.findIndex(s => s.id === svc.id);
-    idx > -1 ? (this.state.services[idx] = svc) : this.state.services.push(svc);
-    this.services$.next([...this.state.services]);
-    this.save();
+    return this.http.post<ServiceItem>(`${this.baseUrl}/services`, svc)
+      .pipe(tap(() => this.refresh()));
   }
 
+  /** Upsert provider via backend */
   upsertProvider(p: Provider) {
-    const idx = this.state.providers.findIndex(x => x.id === p.id);
-    idx > -1 ? (this.state.providers[idx] = p) : this.state.providers.push(p);
-    this.providers$.next([...this.state.providers]);
-    this.save();
+    return this.http.post<Provider>(`${this.baseUrl}/providers`, p)
+      .pipe(tap(() => this.refresh()));
   }
 
   // Convert uploaded image file to Base64 URL
@@ -75,3 +56,4 @@ export class CatalogService {
     });
   }
 }
+

--- a/gptgig/src/app/tabs/pages/admin/admin.page.ts
+++ b/gptgig/src/app/tabs/pages/admin/admin.page.ts
@@ -54,25 +54,28 @@ export class AdminPage {
   async onCatSubmit() {
     const val = this.catForm.value;
     if (!val.id) val.id = 'cat-' +  Date.now().toString();
-    this.catalog.upsertCategory(val as any);
-    this.catForm.reset({ icon: 'briefcase' });
-    this.toastMsg('Category saved');
+    this.catalog.upsertCategory(val as any).subscribe(() => {
+      this.catForm.reset({ icon: 'briefcase' });
+      this.toastMsg('Category saved');
+    });
   }
 
   async onSvcSubmit() {
     const val = this.svcForm.value;
     if (!val.id) val.id = 'svc-' + Date.now().toString();
-    this.catalog.upsertService(val as any);
-    this.svcForm.reset();
-    this.toastMsg('Service saved');
+    this.catalog.upsertService(val as any).subscribe(() => {
+      this.svcForm.reset();
+      this.toastMsg('Service saved');
+    });
   }
 
   async onProvSubmit() {
     const val = this.providerForm.value;
     if (!val.id) val.id = 'pro-' + Date.now().toString();
-    this.catalog.upsertProvider(val as any);
-    this.providerForm.reset({ rating: 4.8 });
-    this.toastMsg('Provider saved');
+    this.catalog.upsertProvider(val as any).subscribe(() => {
+      this.providerForm.reset({ rating: 4.8 });
+      this.toastMsg('Provider saved');
+    });
   }
 
   async handleFile(event: Event, control: 'imageUrl' | 'avatarUrl') {

--- a/gptgigapi/Controllers/CatalogController.cs
+++ b/gptgigapi/Controllers/CatalogController.cs
@@ -1,0 +1,65 @@
+using Microsoft.AspNetCore.Mvc;
+using gptgigapi.Models;
+
+namespace gptgigapi.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class CatalogController : ControllerBase
+    {
+        private static readonly List<ServiceCategory> Categories = new()
+        {
+            new ServiceCategory { Id = "clean", Name = "Cleaning", Icon = "sparkles" },
+            new ServiceCategory { Id = "move", Name = "Moving", Icon = "cube" },
+            new ServiceCategory { Id = "tech", Name = "Tech Help", Icon = "hardware-chip" },
+        };
+
+        private static readonly List<ServiceItem> Services = new()
+        {
+            new ServiceItem { Id = "svc1", Title = "Apartment Deep Clean", CategoryId = "clean", Price = 149, DurationMin = 180, ImageUrl = "assets/samples/clean1.jpg", Rating = 4.9 },
+            new ServiceItem { Id = "svc2", Title = "Two Movers & Truck", CategoryId = "move", Price = 95, DurationMin = 120, ImageUrl = "assets/samples/move1.jpg", Rating = 4.7 },
+            new ServiceItem { Id = "svc3", Title = "Home Wi-Fi Tune Up", CategoryId = "tech", Price = 79, DurationMin = 60, ImageUrl = "assets/samples/tech1.jpg", Rating = 4.8 },
+        };
+
+        private static readonly List<Provider> Providers = new()
+        {
+            new Provider { Id = "pro1", Name = "Avery J.", AvatarUrl = "assets/samples/p1.jpg", Rating = 4.9, Tags = new List<string>{"Cleaning","Move-Out"} },
+            new Provider { Id = "pro2", Name = "Kai M.", AvatarUrl = "assets/samples/p2.jpg", Rating = 4.8, Tags = new List<string>{"Tech Help"} },
+            new Provider { Id = "pro3", Name = "Riley P.", AvatarUrl = "assets/samples/p3.jpg", Rating = 4.7, Tags = new List<string>{"Moving"} },
+        };
+
+        [HttpGet("categories")]
+        public IEnumerable<ServiceCategory> GetCategories() => Categories;
+
+        [HttpGet("services")]
+        public IEnumerable<ServiceItem> GetServices() => Services;
+
+        [HttpGet("providers")]
+        public IEnumerable<Provider> GetProviders() => Providers;
+
+        [HttpPost("categories")]
+        public IActionResult UpsertCategory(ServiceCategory cat)
+        {
+            var idx = Categories.FindIndex(c => c.Id == cat.Id);
+            if (idx >= 0) Categories[idx] = cat; else Categories.Add(cat);
+            return Ok(cat);
+        }
+
+        [HttpPost("services")]
+        public IActionResult UpsertService(ServiceItem svc)
+        {
+            var idx = Services.FindIndex(s => s.Id == svc.Id);
+            if (idx >= 0) Services[idx] = svc; else Services.Add(svc);
+            return Ok(svc);
+        }
+
+        [HttpPost("providers")]
+        public IActionResult UpsertProvider(Provider p)
+        {
+            var idx = Providers.FindIndex(x => x.Id == p.Id);
+            if (idx >= 0) Providers[idx] = p; else Providers.Add(p);
+            return Ok(p);
+        }
+    }
+}
+

--- a/gptgigapi/Models/CatalogModels.cs
+++ b/gptgigapi/Models/CatalogModels.cs
@@ -1,0 +1,32 @@
+namespace gptgigapi.Models
+{
+    public class ServiceCategory
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string? Icon { get; set; }
+    }
+
+    public class ServiceItem
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Title { get; set; } = string.Empty;
+        public string? ImageUrl { get; set; }
+        public decimal? Price { get; set; }
+        public int? DurationMin { get; set; }
+        public string? CategoryId { get; set; }
+        public List<string>? Tags { get; set; }
+        public double? Rating { get; set; }
+    }
+
+    public class Provider
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string? AvatarUrl { get; set; }
+        public double? Rating { get; set; }
+        public List<string>? Tags { get; set; }
+        public List<string>? ServicesOffered { get; set; }
+    }
+}
+


### PR DESCRIPTION
## Summary
- fetch catalog categories, services and providers from backend API
- add admin upload calls to post catalog data
- expose simple in-memory catalog API on backend

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless --no-progress` *(fails: environment lacks required browser)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68aa70ce871083319020d1545bcf4d9b