### PR TITLE
feat: enable CORS for local frontend

### DIFF
--- a/gptgigapi/Program.cs
+++ b/gptgigapi/Program.cs
@@ -40,6 +40,14 @@ builder.Services.AddAuthentication(options =>
 
 builder.Services.AddAuthorization();
 
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("AllowClient", policy =>
+        policy.WithOrigins("http://localhost:8100")
+              .AllowAnyHeader()
+              .AllowAnyMethod());
+});
+
 builder.Services.AddSingleton(_ => new BlobServiceClient(builder.Configuration.GetConnectionString("AzureStorage")));
 
 builder.Services.AddScoped<INotificationService, NotificationService>();
@@ -103,6 +111,8 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+
+app.UseCors("AllowClient");
 
 app.UseAuthentication();
 app.UseAuthorization();


### PR DESCRIPTION
## Summary
- allow http://localhost:8100 to access API via CORS policy

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_b_68aa7699c64c8331ab2d4b2632d1ae19