### PR TITLE
feat: enable card click to add item to cart

### DIFF
--- a/gptgig/src/app/cart/cart.page.html
+++ b/gptgig/src/app/cart/cart.page.html
@@ -5,9 +5,23 @@
 </ion-header>
 
 <ion-content>
-  <ion-list>
-    <ion-item>
-      <ion-label>Your cart is empty.</ion-label>
-    </ion-item>
-  </ion-list>
+  <ng-container *ngIf="cart.selectedItem$ | async as item; else empty">
+    <ion-card>
+      <div class="image" [style.backgroundImage]="'url(' + (item.imageUrl || 'assets/placeholder-rect.jpg') + ')'"></div>
+      <ion-card-header>
+        <ion-card-title>{{ item.title }}</ion-card-title>
+        <ion-card-subtitle *ngIf="item.price != null">
+          {{ item.price | currency:'USD':'symbol':'1.0-0' }}
+        </ion-card-subtitle>
+      </ion-card-header>
+    </ion-card>
+    <app-payment-button [amount]="(item.price || 0) * 100"></app-payment-button>
+  </ng-container>
+  <ng-template #empty>
+    <ion-list>
+      <ion-item>
+        <ion-label>Your cart is empty.</ion-label>
+      </ion-item>
+    </ion-list>
+  </ng-template>
 </ion-content>

--- a/gptgig/src/app/cart/cart.page.scss
+++ b/gptgig/src/app/cart/cart.page.scss
@@ -1,1 +1,7 @@
-/* Empty for now */
+ion-card {
+  .image {
+    height: 140px;
+    background-size: cover;
+    background-position: center;
+  }
+}

--- a/gptgig/src/app/cart/cart.page.spec.ts
+++ b/gptgig/src/app/cart/cart.page.spec.ts
@@ -1,5 +1,13 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { CartPage } from './cart.page';
+import { CartService } from '../services/cart.service';
+import { PaymentService } from '../services/payment.service';
+
+class MockPaymentService {
+  getStripe() { return Promise.resolve(null); }
+  createPaymentRequest() { return Promise.resolve(null); }
+  createPaymentIntent() { return { toPromise: () => Promise.resolve({}) }; }
+}
 
 describe('CartPage', () => {
   let component: CartPage;
@@ -8,6 +16,7 @@ describe('CartPage', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [CartPage],
+      providers: [CartService, { provide: PaymentService, useClass: MockPaymentService }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(CartPage);

--- a/gptgig/src/app/cart/cart.page.ts
+++ b/gptgig/src/app/cart/cart.page.ts
@@ -1,12 +1,16 @@
 import { Component } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { CommonModule, CurrencyPipe } from '@angular/common';
 import { IonicModule } from '@ionic/angular';
+import { CartService } from '../services/cart.service';
+import { PaymentButtonComponent } from '../components/payment-button/payment-button.component';
 
 @Component({
   selector: 'app-cart',
   standalone: true,
-  imports: [IonicModule, CommonModule],
+  imports: [IonicModule, CommonModule, CurrencyPipe, PaymentButtonComponent],
   templateUrl: './cart.page.html',
   styleUrls: ['./cart.page.scss'],
 })
-export class CartPage {}
+export class CartPage {
+  constructor(public cart: CartService) {}
+}

--- a/gptgig/src/app/components/menu-card-rect/menu-card-rect.component.html
+++ b/gptgig/src/app/components/menu-card-rect/menu-card-rect.component.html
@@ -1,4 +1,4 @@
-<ion-card class="rect">
+<ion-card class="rect" (click)="select()">
   <div class="image" [style.backgroundImage]="'url(' + (item.imageUrl || 'assets/placeholder-rect.jpg') + ')'"></div>
   <ion-card-header>
     <ion-card-title>{{ item.title }}</ion-card-title>

--- a/gptgig/src/app/components/menu-card-rect/menu-card-rect.component.spec.ts
+++ b/gptgig/src/app/components/menu-card-rect/menu-card-rect.component.spec.ts
@@ -1,7 +1,9 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { MenuCardRectComponent } from './menu-card-rect.component';
+import { CartService } from '../../services/cart.service';
 
 describe('MenuCardRectComponent', () => {
   let component: MenuCardRectComponent;
@@ -9,12 +11,13 @@ describe('MenuCardRectComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [ MenuCardRectComponent ],
-      imports: [IonicModule.forRoot()]
+      imports: [MenuCardRectComponent, IonicModule.forRoot(), RouterTestingModule],
+      providers: [CartService]
     }).compileComponents();
 
     fixture = TestBed.createComponent(MenuCardRectComponent);
     component = fixture.componentInstance;
+    component.item = { id: '1', title: 'Test Item', price: 10 } as any;
     fixture.detectChanges();
   }));
 

--- a/gptgig/src/app/components/menu-card-rect/menu-card-rect.component.ts
+++ b/gptgig/src/app/components/menu-card-rect/menu-card-rect.component.ts
@@ -1,7 +1,9 @@
 import { Component, Input } from '@angular/core';
 import { IonicModule } from '@ionic/angular';
 import { CommonModule, CurrencyPipe } from '@angular/common';
+import { Router } from '@angular/router';
 import { ServiceItem } from '../../models/catalog.models';
+import { CartService } from '../../services/cart.service';
 
 @Component({
   standalone: true,
@@ -12,4 +14,11 @@ import { ServiceItem } from '../../models/catalog.models';
 })
 export class MenuCardRectComponent {
   @Input() item!: ServiceItem;
+
+  constructor(private cart: CartService, private router: Router) {}
+
+  select() {
+    this.cart.selectItem(this.item);
+    this.router.navigate(['/cart']);
+  }
 }

--- a/gptgig/src/app/services/cart.service.ts
+++ b/gptgig/src/app/services/cart.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { ServiceItem } from '../models/catalog.models';
+
+@Injectable({ providedIn: 'root' })
+export class CartService {
+  private selectedItemSubject = new BehaviorSubject<ServiceItem | null>(null);
+  selectedItem$ = this.selectedItemSubject.asObservable();
+
+  selectItem(item: ServiceItem) {
+    this.selectedItemSubject.next(item);
+  }
+
+  clear() {
+    this.selectedItemSubject.next(null);
+  }
+
+  getSelectedItem(): ServiceItem | null {
+    return this.selectedItemSubject.value;
+  }
+}
+


### PR DESCRIPTION
## Summary
- make service cards clickable and route to cart
- add cart service and payment button integration
- show selected item in cart with Stripe payment button

## Testing
- `npm run lint` (fails: Prefer using the inject function and empty lifecycle methods)
- `npm test` (fails: No binary for Chrome)
- `dotnet test gptgigapi/gptgigapi.sln` (fails: command not found: dotnet)


------
https://chatgpt.com/codex/tasks/task_b_68ac78cf777883319dea20a5fb910d31