### PR TITLE
fix: type payment request event

### DIFF
--- a/gptgig/src/app/components/payment-button/payment-button.component.ts
+++ b/gptgig/src/app/components/payment-button/payment-button.component.ts
@@ -1,4 +1,5 @@
 import { Component, ElementRef, Input, OnInit } from '@angular/core';
+import { PaymentRequestPaymentMethodEvent } from '@stripe/stripe-js';
 import { PaymentService } from '../../services/payment.service';
 
 @Component({
@@ -37,7 +38,7 @@ export class PaymentButtonComponent implements OnInit {
     });
     prButton.mount(this.el.nativeElement.querySelector('#payment-request-button'));
 
-    paymentRequest.on('paymentmethod', async (ev) => {
+    paymentRequest.on('paymentmethod', async (ev: PaymentRequestPaymentMethodEvent) => {
       const intent = await this.paymentService.createPaymentIntent(this.amount, this.currency).toPromise();
       const clientSecret = intent?.clientSecret;
       if (!clientSecret) {


### PR DESCRIPTION
## Summary
- add explicit type for Stripe payment request event

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_b_68ac7c902f5083319c0c68cd79ccc67d