### PR TITLE
chore: ignore Visual Studio build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,19 @@
-
+# Visual Studio artifacts
+.vs/
 *.vsidx
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# Build results
+[Bb]in/
+[Oo]bj/
+[Dd]ebug*/
+[Rr]elease*/
+[Xx]64/
+[Xx]86/
+
+# Logs
+*.log
+


### PR DESCRIPTION
## Summary
- ignore Visual Studio temporary files and build output

## Testing
- `npm test` *(fails: Property 'stripePublishableKey' does not exist; merge conflict markers in environment.ts)*
- `dotnet test gptgigapi/gptgigapi.csproj`


------
https://chatgpt.com/codex/tasks/task_b_68acf228d8088331bcff90c86c5d66bd