### PR TITLE
feat: show profile modal on toolbar avatar click

### DIFF
--- a/gptgig/src/app/components/page-toolbar/page-toolbar.component.html
+++ b/gptgig/src/app/components/page-toolbar/page-toolbar.component.html
@@ -8,10 +8,10 @@
       <ion-searchbar placeholder="Search" (ionInput)="onSearch($event)"></ion-searchbar>
   
     </ion-buttons>
-    <ion-buttons slot="end">
-      <ion-avatar>
-        <img [src]="avatarSrc" alt="Profile" />
-      </ion-avatar>
-    </ion-buttons>
+      <ion-buttons slot="end">
+        <ion-avatar (click)="openProfileModal()">
+          <img [src]="avatarSrc" alt="Profile" />
+        </ion-avatar>
+      </ion-buttons>
   </ion-toolbar>
 </ion-header>

--- a/gptgig/src/app/components/page-toolbar/page-toolbar.component.ts
+++ b/gptgig/src/app/components/page-toolbar/page-toolbar.component.ts
@@ -1,6 +1,7 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
-import { IonicModule } from '@ionic/angular';
+import { IonicModule, ModalController } from '@ionic/angular';
 import { CommonModule } from '@angular/common';
+import { ProfileModalComponent } from '../profile-modal/profile-modal.component';
 
 @Component({
   selector: 'app-page-toolbar',
@@ -14,8 +15,17 @@ export class PageToolbarComponent {
   @Input() avatarSrc = 'assets/icon/favicon.png';
   @Output() searchChange = new EventEmitter<string>();
 
+  constructor(private modalCtrl: ModalController) {}
+
   onSearch(event: any) {
     const value = event?.target?.value ?? '';
     this.searchChange.emit(value);
+  }
+
+  async openProfileModal() {
+    const modal = await this.modalCtrl.create({
+      component: ProfileModalComponent,
+    });
+    await modal.present();
   }
 }

--- a/gptgig/src/app/components/profile-modal/profile-modal.component.html
+++ b/gptgig/src/app/components/profile-modal/profile-modal.component.html
@@ -1,0 +1,12 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Profile</ion-title>
+    <ion-buttons slot="end">
+      <ion-button (click)="dismiss()">Close</ion-button>
+    </ion-buttons>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content class="ion-padding">
+  <p>Your profile information goes here.</p>
+</ion-content>

--- a/gptgig/src/app/components/profile-modal/profile-modal.component.scss
+++ b/gptgig/src/app/components/profile-modal/profile-modal.component.scss
@@ -1,0 +1,1 @@
+/* profile modal styles */

--- a/gptgig/src/app/components/profile-modal/profile-modal.component.spec.ts
+++ b/gptgig/src/app/components/profile-modal/profile-modal.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ProfileModalComponent } from './profile-modal.component';
+import { IonicModule } from '@ionic/angular';
+
+describe('ProfileModalComponent', () => {
+  let component: ProfileModalComponent;
+  let fixture: ComponentFixture<ProfileModalComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ProfileModalComponent, IonicModule.forRoot()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProfileModalComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/gptgig/src/app/components/profile-modal/profile-modal.component.ts
+++ b/gptgig/src/app/components/profile-modal/profile-modal.component.ts
@@ -1,0 +1,18 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IonicModule, ModalController } from '@ionic/angular';
+
+@Component({
+  selector: 'app-profile-modal',
+  standalone: true,
+  imports: [IonicModule, CommonModule],
+  templateUrl: './profile-modal.component.html',
+  styleUrls: ['./profile-modal.component.scss'],
+})
+export class ProfileModalComponent {
+  constructor(private modalCtrl: ModalController) {}
+
+  dismiss() {
+    this.modalCtrl.dismiss();
+  }
+}


### PR DESCRIPTION
## Summary
- open profile modal when toolbar avatar is clicked
- add standalone ProfileModal component

## Testing
- `npm test` *(fails: Property 'stripePublishableKey' does not exist and merge conflict markers in environment.ts)*
- `npm run lint` *(fails: parsing error from environment.ts and many lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_68ae02a6c13c8331bb41959a5d0fa86e