### PR TITLE
Add item detail page and admin-configurable descriptions

### DIFF
--- a/gptgig/src/app/app.routes.ts
+++ b/gptgig/src/app/app.routes.ts
@@ -17,4 +17,9 @@ export const routes: Routes = [
     path: 'cart',
     loadComponent: () => import('./cart/cart.page').then((m) => m.CartPage),
   },
+  {
+    path: 'item/:id',
+    loadComponent: () =>
+      import('./item-detail/item-detail.page').then((m) => m.ItemDetailPage),
+  },
 ];

--- a/gptgig/src/app/components/menu-card-rect/menu-card-rect.component.spec.ts
+++ b/gptgig/src/app/components/menu-card-rect/menu-card-rect.component.spec.ts
@@ -3,16 +3,13 @@ import { IonicModule } from '@ionic/angular';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { MenuCardRectComponent } from './menu-card-rect.component';
-import { CartService } from '../../services/cart.service';
-
 describe('MenuCardRectComponent', () => {
   let component: MenuCardRectComponent;
   let fixture: ComponentFixture<MenuCardRectComponent>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [MenuCardRectComponent, IonicModule.forRoot(), RouterTestingModule],
-      providers: [CartService]
+      imports: [MenuCardRectComponent, IonicModule.forRoot(), RouterTestingModule]
     }).compileComponents();
 
     fixture = TestBed.createComponent(MenuCardRectComponent);

--- a/gptgig/src/app/components/menu-card-rect/menu-card-rect.component.ts
+++ b/gptgig/src/app/components/menu-card-rect/menu-card-rect.component.ts
@@ -3,7 +3,6 @@ import { IonicModule } from '@ionic/angular';
 import { CommonModule, CurrencyPipe } from '@angular/common';
 import { Router } from '@angular/router';
 import { ServiceItem } from '../../models/catalog.models';
-import { CartService } from '../../services/cart.service';
 
 @Component({
   standalone: true,
@@ -15,10 +14,9 @@ import { CartService } from '../../services/cart.service';
 export class MenuCardRectComponent {
   @Input() item!: ServiceItem;
 
-  constructor(private cart: CartService, private router: Router) {}
+  constructor(private router: Router) {}
 
   select() {
-    this.cart.selectItem(this.item);
-    this.router.navigate(['/cart']);
+    this.router.navigate(['/item', this.item.id]);
   }
 }

--- a/gptgig/src/app/item-detail/item-detail.page.html
+++ b/gptgig/src/app/item-detail/item-detail.page.html
@@ -1,0 +1,22 @@
+<ion-header *ngIf="item">
+  <ion-toolbar>
+    <ion-title>{{ item.title }}</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content *ngIf="item" [fullscreen]="true">
+  <div class="image-wrapper">
+    <img [src]="item.imageUrl || 'assets/placeholder-rect.jpg'" alt="{{ item.title }}" />
+  </div>
+  <div class="info">
+    <h2>{{ item.title }}</h2>
+    <div class="price" *ngIf="item.price">{{ item.price | currency:'USD':'symbol' }}</div>
+    <div class="description" *ngIf="item.description">{{ item.description }}</div>
+  </div>
+  <ion-button expand="block" color="primary" (click)="addToCart()">Add to Cart</ion-button>
+</ion-content>
+
+<ion-content *ngIf="!item">
+  <p class="empty">Item not found.</p>
+</ion-content>
+

--- a/gptgig/src/app/item-detail/item-detail.page.scss
+++ b/gptgig/src/app/item-detail/item-detail.page.scss
@@ -1,0 +1,34 @@
+.image-wrapper {
+  display: flex;
+  justify-content: center;
+  padding: 16px;
+  img {
+    max-width: 100%;
+    height: auto;
+  }
+}
+
+.info {
+  padding: 0 16px;
+
+  h2 {
+    margin-top: 8px;
+    font-size: 1.4rem;
+  }
+
+  .price {
+    color: #b12704;
+    font-weight: bold;
+    margin: 8px 0;
+  }
+
+  .description {
+    margin-top: 8px;
+  }
+}
+
+.empty {
+  text-align: center;
+  margin-top: 2rem;
+}
+

--- a/gptgig/src/app/item-detail/item-detail.page.spec.ts
+++ b/gptgig/src/app/item-detail/item-detail.page.spec.ts
@@ -1,0 +1,34 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute } from '@angular/router';
+import { BehaviorSubject } from 'rxjs';
+
+import { ItemDetailPage } from './item-detail.page';
+import { CatalogService } from '../services/catalog.service';
+import { CartService } from '../services/cart.service';
+
+describe('ItemDetailPage', () => {
+  let component: ItemDetailPage;
+  let fixture: ComponentFixture<ItemDetailPage>;
+  const services$ = new BehaviorSubject<any[]>([{ id: '1', title: 'Test', description: 'desc' }]);
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ItemDetailPage, RouterTestingModule],
+      providers: [
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => '1' } } } },
+        { provide: CatalogService, useValue: { services$ } },
+        { provide: CartService, useValue: { selectItem: () => {} } }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ItemDetailPage);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});
+

--- a/gptgig/src/app/item-detail/item-detail.page.ts
+++ b/gptgig/src/app/item-detail/item-detail.page.ts
@@ -1,0 +1,39 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { IonicModule } from '@ionic/angular';
+import { CommonModule, CurrencyPipe } from '@angular/common';
+import { ActivatedRoute, Router } from '@angular/router';
+import { CatalogService } from '../services/catalog.service';
+import { CartService } from '../services/cart.service';
+import { ServiceItem } from '../models/catalog.models';
+
+@Component({
+  selector: 'app-item-detail',
+  standalone: true,
+  imports: [IonicModule, CommonModule, CurrencyPipe],
+  templateUrl: './item-detail.page.html',
+  styleUrls: ['./item-detail.page.scss']
+})
+export class ItemDetailPage implements OnInit {
+  item?: ServiceItem;
+
+  private route = inject(ActivatedRoute);
+  private catalog = inject(CatalogService);
+  private cart = inject(CartService);
+  private router = inject(Router);
+
+  ngOnInit() {
+    const id = this.route.snapshot.paramMap.get('id');
+    if (id) {
+      const items = this.catalog.services$.value;
+      this.item = items.find((s) => s.id === id);
+    }
+  }
+
+  addToCart() {
+    if (this.item) {
+      this.cart.selectItem(this.item);
+      this.router.navigate(['/cart']);
+    }
+  }
+}
+

--- a/gptgig/src/app/models/catalog.models.ts
+++ b/gptgig/src/app/models/catalog.models.ts
@@ -13,6 +13,7 @@ export interface ServiceItem {
   categoryId?: string;
   tags?: string[];
   rating?: number;
+  description?: string;
 }
 
 export interface Provider {

--- a/gptgig/src/app/tabs/pages/admin/admin.page.html
+++ b/gptgig/src/app/tabs/pages/admin/admin.page.html
@@ -38,6 +38,9 @@
         <ion-item>
           <ion-input type="number" formControlName="durationMin" label="Duration (min)" labelPlacement="stacked"></ion-input>
         </ion-item>
+        <ion-item>
+          <ion-textarea formControlName="description" label="Description" labelPlacement="stacked"></ion-textarea>
+        </ion-item>
         <ion-item lines="none" *ngIf="!isMobile">
           <ion-label>Image</ion-label>
           <input type="file" accept="image/*" (change)="handleFile($event, 'imageUrl')" />

--- a/gptgig/src/app/tabs/pages/admin/admin.page.ts
+++ b/gptgig/src/app/tabs/pages/admin/admin.page.ts
@@ -41,7 +41,8 @@ export class AdminPage {
     categoryId: [''],
     price: [null],
     durationMin: [null],
-    imageUrl: ['']
+    imageUrl: [''],
+    description: ['']
   });
 
   providerForm = this.fb.group({

--- a/gptgig/src/environments/environment.ts
+++ b/gptgig/src/environments/environment.ts
@@ -1,9 +1,5 @@
 export const environment = {
   production: false,
-<<<<<<< HEAD
-  apiUrl: 'https://localhost:7200/api'
-=======
-  apiUrl: 'https://localhost:5001/api',
+  apiUrl: 'https://localhost:7200/api',
   stripePublishableKey: 'pk_test_your_key'
->>>>>>> origin/main
 };

--- a/gptgigapi/Controllers/CatalogController.cs
+++ b/gptgigapi/Controllers/CatalogController.cs
@@ -16,9 +16,9 @@ namespace gptgigapi.Controllers
 
         private static readonly List<ServiceItem> Services = new()
         {
-            new ServiceItem { Id = "svc1", Title = "Apartment Deep Clean", CategoryId = "clean", Price = 149, DurationMin = 180, ImageUrl = "assets/samples/clean1.jpg", Rating = 4.9 },
-            new ServiceItem { Id = "svc2", Title = "Two Movers & Truck", CategoryId = "move", Price = 95, DurationMin = 120, ImageUrl = "assets/samples/move1.jpg", Rating = 4.7 },
-            new ServiceItem { Id = "svc3", Title = "Home Wi-Fi Tune Up", CategoryId = "tech", Price = 79, DurationMin = 60, ImageUrl = "assets/samples/tech1.jpg", Rating = 4.8 },
+            new ServiceItem { Id = "svc1", Title = "Apartment Deep Clean", CategoryId = "clean", Price = 149, DurationMin = 180, ImageUrl = "assets/samples/clean1.jpg", Rating = 4.9, Description = "Professional deep cleaning for your entire apartment." },
+            new ServiceItem { Id = "svc2", Title = "Two Movers & Truck", CategoryId = "move", Price = 95, DurationMin = 120, ImageUrl = "assets/samples/move1.jpg", Rating = 4.7, Description = "Reliable moving service with two helpers and a truck." },
+            new ServiceItem { Id = "svc3", Title = "Home Wi-Fi Tune Up", CategoryId = "tech", Price = 79, DurationMin = 60, ImageUrl = "assets/samples/tech1.jpg", Rating = 4.8, Description = "Optimize and secure your home wireless network." },
         };
 
         private static readonly List<Provider> Providers = new()

--- a/gptgigapi/Models/CatalogModels.cs
+++ b/gptgigapi/Models/CatalogModels.cs
@@ -17,6 +17,7 @@ namespace gptgigapi.Models
         public string? CategoryId { get; set; }
         public List<string>? Tags { get; set; }
         public double? Rating { get; set; }
+        public string? Description { get; set; }
     }
 
     public class Provider


### PR DESCRIPTION
## Summary
- Redirect service cards to a new Amazon-style item detail page with add-to-cart action
- Enable service descriptions editable via admin page and persisted through API
- Extend catalog models and backend fixtures to support item descriptions

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_b_68ae032aa0bc83318e575f2210129d97