### PR TITLE
Move admin tab into profile modal

### DIFF
--- a/gptgig/src/app/components/profile-modal/profile-modal.component.html
+++ b/gptgig/src/app/components/profile-modal/profile-modal.component.html
@@ -8,5 +8,8 @@
 </ion-header>
 
 <ion-content class="ion-padding">
+  <ion-list>
+    <ion-item button (click)="goToAdmin()">Admin</ion-item>
+  </ion-list>
   <p>Your profile information goes here.</p>
 </ion-content>

--- a/gptgig/src/app/components/profile-modal/profile-modal.component.spec.ts
+++ b/gptgig/src/app/components/profile-modal/profile-modal.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ProfileModalComponent } from './profile-modal.component';
 import { IonicModule } from '@ionic/angular';
+import { RouterTestingModule } from '@angular/router/testing';
 
 describe('ProfileModalComponent', () => {
   let component: ProfileModalComponent;
@@ -8,7 +9,7 @@ describe('ProfileModalComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ProfileModalComponent, IonicModule.forRoot()],
+      imports: [ProfileModalComponent, IonicModule.forRoot(), RouterTestingModule],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ProfileModalComponent);

--- a/gptgig/src/app/components/profile-modal/profile-modal.component.ts
+++ b/gptgig/src/app/components/profile-modal/profile-modal.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { IonicModule, ModalController } from '@ionic/angular';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-profile-modal',
@@ -10,9 +11,14 @@ import { IonicModule, ModalController } from '@ionic/angular';
   styleUrls: ['./profile-modal.component.scss'],
 })
 export class ProfileModalComponent {
-  constructor(private modalCtrl: ModalController) {}
+  constructor(private modalCtrl: ModalController, private router: Router) {}
 
   dismiss() {
     this.modalCtrl.dismiss();
+  }
+
+  async goToAdmin() {
+    await this.modalCtrl.dismiss();
+    this.router.navigateByUrl('/tabs/admin');
   }
 }

--- a/gptgig/src/app/tabs/tabs.page.html
+++ b/gptgig/src/app/tabs/tabs.page.html
@@ -45,9 +45,5 @@
       <ion-icon name="person"></ion-icon>
       <ion-label>Profile</ion-label>
     </ion-tab-button>
-     <ion-tab-button tab="admin" href="['/tabs/admin">
-      <ion-icon name="admin"></ion-icon>
-      <ion-label>Admin</ion-label>
-    </ion-tab-button>
   </ion-tab-bar>
 </ion-tabs>


### PR DESCRIPTION
## Summary
- remove bottom nav admin tab
- add Admin option in profile modal opened from avatar
- wire admin selection to existing admin route

## Testing
- `npm test -- --watch=false` *(fails: ChromeHeadless failed to start)*
- `npm run lint` *(fails: lint errors in multiple files)*

------
https://chatgpt.com/codex/tasks/task_b_68ae7c2e60ac8331b16ae5ed95d87b0f