### PR TITLE
refactor: convert admin panel into wizard

### DIFF
--- a/gptgig/src/app/tabs/pages/admin/admin.page.html
+++ b/gptgig/src/app/tabs/pages/admin/admin.page.html
@@ -1,97 +1,112 @@
 <app-page-toolbar title="Admin"></app-page-toolbar>
 
 <ion-content class="admin">
-  <ion-card>
-    <ion-card-header>
-      <ion-card-title>Service Categories</ion-card-title>
-    </ion-card-header>
-    <ion-card-content>
-      <form [formGroup]="catForm" (ngSubmit)="onCatSubmit()">
-        <ion-item>
-          <ion-input formControlName="name" label="Name" labelPlacement="floating" required></ion-input>
-        </ion-item>
-        <ion-item>
-          <ion-input formControlName="icon" label="Icon (ionicon name)" labelPlacement="stacked"></ion-input>
-        </ion-item>
-        <ion-button type="submit" expand="block">Save Category</ion-button>
-      </form>
-    </ion-card-content>
-  </ion-card>
+  <!-- Step 1: Category setup -->
+  <ng-container *ngIf="step === 1">
+    <ion-card>
+      <ion-card-header>
+        <ion-card-title>Service Categories</ion-card-title>
+      </ion-card-header>
+      <ion-card-content>
+        <form [formGroup]="catForm" (ngSubmit)="onCatSubmit()">
+          <ion-item>
+            <ion-input formControlName="name" label="Name" labelPlacement="floating" required></ion-input>
+          </ion-item>
+          <ion-item>
+            <ion-input formControlName="icon" label="Icon (ionicon name)" labelPlacement="stacked"></ion-input>
+          </ion-item>
+          <ion-button type="submit" expand="block">Save & Next</ion-button>
+        </form>
+      </ion-card-content>
+    </ion-card>
+  </ng-container>
 
-  <ion-card>
-    <ion-card-header>
-      <ion-card-title>Services (Rect Cards)</ion-card-title>
-    </ion-card-header>
-    <ion-card-content>
-      <form [formGroup]="svcForm" (ngSubmit)="onSvcSubmit()">
-        <ion-item>
-          <ion-input formControlName="title" label="Title" labelPlacement="floating" required></ion-input>
-        </ion-item>
-        <ion-item>
-          <ion-select formControlName="categoryId" label="Category" labelPlacement="stacked" interface="popover">
-            <ion-select-option *ngFor="let c of (categories$ | async)" [value]="c.id">{{c.name}}</ion-select-option>
-          </ion-select>
-        </ion-item>
-        <ion-item>
-          <ion-input type="number" formControlName="price" label="Price (USD)" labelPlacement="stacked"></ion-input>
-        </ion-item>
-        <ion-item>
-          <ion-input type="number" formControlName="durationMin" label="Duration (min)" labelPlacement="stacked"></ion-input>
-        </ion-item>
-        <ion-item>
-          <ion-textarea formControlName="description" label="Description" labelPlacement="stacked"></ion-textarea>
-        </ion-item>
-        <ion-item lines="none" *ngIf="!isMobile">
-          <ion-label>Image</ion-label>
-          <input type="file" accept="image/*" (change)="handleFile($event, 'imageUrl')" />
-        </ion-item>
-        <ion-item lines="none" *ngIf="isMobile">
-          <ion-label>Image</ion-label>
-          <ion-button (click)="captureImage('imageUrl')">Take Photo</ion-button>
-        </ion-item>
-        <ion-button type="submit" expand="block">Save Service</ion-button>
-      </form>
-    </ion-card-content>
-  </ion-card>
+  <!-- Step 2: Service setup -->
+  <ng-container *ngIf="step === 2">
+    <ion-card>
+      <ion-card-header>
+        <ion-card-title>Services (Rect Cards)</ion-card-title>
+      </ion-card-header>
+      <ion-card-content>
+        <form [formGroup]="svcForm" (ngSubmit)="onSvcSubmit()">
+          <ion-item>
+            <ion-input formControlName="title" label="Title" labelPlacement="floating" required></ion-input>
+          </ion-item>
+          <ion-item>
+            <ion-select formControlName="categoryId" label="Category" labelPlacement="stacked" interface="popover">
+              <ion-select-option *ngFor="let c of (categories$ | async)" [value]="c.id">{{c.name}}</ion-select-option>
+            </ion-select>
+          </ion-item>
+          <ion-item>
+            <ion-input type="number" formControlName="price" label="Price (USD)" labelPlacement="stacked"></ion-input>
+          </ion-item>
+          <ion-item>
+            <ion-input type="number" formControlName="durationMin" label="Duration (min)" labelPlacement="stacked"></ion-input>
+          </ion-item>
+          <ion-item>
+            <ion-textarea formControlName="description" label="Description" labelPlacement="stacked"></ion-textarea>
+          </ion-item>
+          <ion-item lines="none" *ngIf="!isMobile">
+            <ion-label>Image</ion-label>
+            <input type="file" accept="image/*" (change)="handleFile($event, 'imageUrl')" />
+          </ion-item>
+          <ion-item lines="none" *ngIf="isMobile">
+            <ion-label>Image</ion-label>
+            <ion-button (click)="captureImage('imageUrl')">Take Photo</ion-button>
+          </ion-item>
+          <ion-button type="button" expand="block" (click)="goBack()">Back</ion-button>
+          <ion-button type="submit" expand="block">Save & Next</ion-button>
+        </form>
+      </ion-card-content>
+    </ion-card>
+  </ng-container>
 
-  <ion-card>
-    <ion-card-header>
-      <ion-card-title>Providers (Circular Cards)</ion-card-title>
-    </ion-card-header>
-    <ion-card-content>
-      <form [formGroup]="providerForm" (ngSubmit)="onProvSubmit()">
-        <ion-item>
-          <ion-input formControlName="name" label="Name" labelPlacement="floating" required></ion-input>
-        </ion-item>
-        <ion-item>
-          <ion-input type="number" formControlName="rating" label="Rating" labelPlacement="stacked"></ion-input>
-        </ion-item>
-        <ion-item lines="none" *ngIf="!isMobile">
-          <ion-label>Avatar</ion-label>
-          <input type="file" accept="image/*" (change)="handleFile($event, 'avatarUrl')" />
-        </ion-item>
-        <ion-item lines="none" *ngIf="isMobile">
-          <ion-label>Avatar</ion-label>
-          <ion-button (click)="captureImage('avatarUrl')">Take Photo</ion-button>
-        </ion-item>
-        <ion-button type="submit" expand="block">Save Provider</ion-button>
-      </form>
-    </ion-card-content>
-  </ion-card>
+  <!-- Step 3: Provider setup -->
+  <ng-container *ngIf="step === 3">
+    <ion-card>
+      <ion-card-header>
+        <ion-card-title>Providers (Circular Cards)</ion-card-title>
+      </ion-card-header>
+      <ion-card-content>
+        <form [formGroup]="providerForm" (ngSubmit)="onProvSubmit()">
+          <ion-item>
+            <ion-input formControlName="name" label="Name" labelPlacement="floating" required></ion-input>
+          </ion-item>
+          <ion-item>
+            <ion-input type="number" formControlName="rating" label="Rating" labelPlacement="stacked"></ion-input>
+          </ion-item>
+          <ion-item lines="none" *ngIf="!isMobile">
+            <ion-label>Avatar</ion-label>
+            <input type="file" accept="image/*" (change)="handleFile($event, 'avatarUrl')" />
+          </ion-item>
+          <ion-item lines="none" *ngIf="isMobile">
+            <ion-label>Avatar</ion-label>
+            <ion-button (click)="captureImage('avatarUrl')">Take Photo</ion-button>
+          </ion-item>
+          <ion-button type="button" expand="block" (click)="goBack()">Back</ion-button>
+          <ion-button type="submit" expand="block">Save & Next</ion-button>
+        </form>
+      </ion-card-content>
+    </ion-card>
+  </ng-container>
 
-  <ion-card>
-    <ion-card-header>
-      <ion-card-title>Current Services</ion-card-title>
-    </ion-card-header>
-    <ion-card-content>
-      <ion-item *ngFor="let s of (services$ | async)">
-        <ion-thumbnail slot="start"><img [src]="s.imageUrl || 'assets/placeholder-rect.jpg'"></ion-thumbnail>
-        <ion-label>
-          <div>{{s.title}}</div>
-          <small>{{s.price ? ('$'+s.price) : ''}}</small>
-        </ion-label>
-      </ion-item>
-    </ion-card-content>
-  </ion-card>
+  <!-- Step 4: Review current services -->
+  <ng-container *ngIf="step === 4">
+    <ion-card>
+      <ion-card-header>
+        <ion-card-title>Current Services</ion-card-title>
+      </ion-card-header>
+      <ion-card-content>
+        <ion-item *ngFor="let s of (services$ | async)">
+          <ion-thumbnail slot="start"><img [src]="s.imageUrl || 'assets/placeholder-rect.jpg'"></ion-thumbnail>
+          <ion-label>
+            <div>{{s.title}}</div>
+            <small>{{s.price ? ('$'+s.price) : ''}}</small>
+          </ion-label>
+        </ion-item>
+        <ion-button expand="block" (click)="goBack()">Back</ion-button>
+      </ion-card-content>
+    </ion-card>
+  </ng-container>
 </ion-content>
 

--- a/gptgig/src/app/tabs/pages/admin/admin.page.spec.ts
+++ b/gptgig/src/app/tabs/pages/admin/admin.page.spec.ts
@@ -14,4 +14,8 @@ describe('AdminPage', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should start at step 1', () => {
+    expect(component.step).toBe(1);
+  });
 });

--- a/gptgig/src/app/tabs/pages/admin/admin.page.ts
+++ b/gptgig/src/app/tabs/pages/admin/admin.page.ts
@@ -29,6 +29,8 @@ export class AdminPage {
   services$   = this.catalog.services$;
   providers$  = this.catalog.providers$;
 
+  step = 1;
+
   catForm = this.fb.group({
     id: [''],
     name: ['', Validators.required],
@@ -58,6 +60,7 @@ export class AdminPage {
     this.catalog.upsertCategory(val as any).subscribe(() => {
       this.catForm.reset({ icon: 'briefcase' });
       this.toastMsg('Category saved');
+      this.goNext();
     });
   }
 
@@ -67,6 +70,7 @@ export class AdminPage {
     this.catalog.upsertService(val as any).subscribe(() => {
       this.svcForm.reset();
       this.toastMsg('Service saved');
+      this.goNext();
     });
   }
 
@@ -76,6 +80,7 @@ export class AdminPage {
     this.catalog.upsertProvider(val as any).subscribe(() => {
       this.providerForm.reset({ rating: 4.8 });
       this.toastMsg('Provider saved');
+      this.goNext();
     });
   }
 
@@ -86,6 +91,14 @@ export class AdminPage {
       if (control === 'imageUrl') this.svcForm.patchValue({ imageUrl: base64 });
       if (control === 'avatarUrl') this.providerForm.patchValue({ avatarUrl: base64 });
     }
+  }
+
+  goNext() {
+    if (this.step < 4) this.step++;
+  }
+
+  goBack() {
+    if (this.step > 1) this.step--;
   }
 
   async captureImage(control: 'imageUrl' | 'avatarUrl') {


### PR DESCRIPTION
## Summary
- redesign admin panel as a multi-step wizard for categories, services, providers and review
- add step navigation logic to admin page component
- test initial step value

## Testing
- `npm test -- --no-watch --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_b_68ae7d05d3008331bcc215e6cbc4600a