### PR TITLE
feat: add close button to item details card

### DIFF
--- a/gptgig/src/app/cart/cart.page.html
+++ b/gptgig/src/app/cart/cart.page.html
@@ -7,7 +7,19 @@
 <ion-content>
   <ng-container *ngIf="cart.selectedItem$ | async as item; else empty">
     <ion-card>
-      <div class="image" [style.backgroundImage]="'url(' + (item.imageUrl || 'assets/placeholder-rect.jpg') + ')'"></div>
+      <ion-button
+        class="close-btn"
+        fill="clear"
+        size="small"
+        aria-label="Close"
+        (click)="cart.clear()"
+      >
+        <ion-icon name="close"></ion-icon>
+      </ion-button>
+      <div
+        class="image"
+        [style.backgroundImage]="'url(' + (item.imageUrl || 'assets/placeholder-rect.jpg') + ')'"
+      ></div>
       <ion-card-header>
         <ion-card-title>{{ item.title }}</ion-card-title>
         <ion-card-subtitle *ngIf="item.price != null">

--- a/gptgig/src/app/cart/cart.page.scss
+++ b/gptgig/src/app/cart/cart.page.scss
@@ -1,7 +1,16 @@
 ion-card {
+  position: relative;
+
   .image {
     height: 140px;
     background-size: cover;
     background-position: center;
+  }
+
+  .close-btn {
+    position: absolute;
+    top: 4px;
+    right: 4px;
+    z-index: 1;
   }
 }


### PR DESCRIPTION
## Summary
- add close button to cart item details card
- style close button to sit at top right of the card

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_b_68ae7fd9f47483319e9d428721f9e07c