### PR TITLE
Rename search tab to cart and profile to social

### DIFF
--- a/gptgig/src/app/tabs/pages/profile/profile.page.html
+++ b/gptgig/src/app/tabs/pages/profile/profile.page.html
@@ -1,9 +1,9 @@
-<app-page-toolbar title="Profile"></app-page-toolbar>
+<app-page-toolbar title="Social"></app-page-toolbar>
 
 <ion-content [fullscreen]="true">
   <ion-header collapse="condense">
     <ion-toolbar>
-      <ion-title size="large">profile</ion-title>
+      <ion-title size="large">social</ion-title>
     </ion-toolbar>
   </ion-header>
 </ion-content>

--- a/gptgig/src/app/tabs/tabs.page.html
+++ b/gptgig/src/app/tabs/tabs.page.html
@@ -26,9 +26,9 @@
       <ion-label>Home</ion-label>
     </ion-tab-button>
 
-    <ion-tab-button tab="search" href="['/tabs/search']">
-      <ion-icon name="search"></ion-icon>
-      <ion-label>Search</ion-label>
+    <ion-tab-button tab="cart" href="['/tabs/cart']">
+      <ion-icon name="cart"></ion-icon>
+      <ion-label>Cart</ion-label>
     </ion-tab-button>
 
     <ion-tab-button tab="services" href="['/tabs/services']">
@@ -41,9 +41,9 @@
       <ion-label>Inbox</ion-label>
     </ion-tab-button>
 
-    <ion-tab-button tab="profile" href="['/tabs/profile']">
-      <ion-icon name="person"></ion-icon>
-      <ion-label>Profile</ion-label>
+    <ion-tab-button tab="social" href="['/tabs/social']">
+      <ion-icon name="megaphone"></ion-icon>
+      <ion-label>Social</ion-label>
     </ion-tab-button>
   </ion-tab-bar>
 </ion-tabs>

--- a/gptgig/src/app/tabs/tabs.page.ts
+++ b/gptgig/src/app/tabs/tabs.page.ts
@@ -1,7 +1,7 @@
 import { Component, EnvironmentInjector, inject } from '@angular/core';
 import { IonTabs, IonTabBar, IonTabButton, IonIcon, IonLabel, IonRouterOutlet } from '@ionic/angular/standalone';
 import { addIcons } from 'ionicons';
-import { home, search, briefcase, mail, person } from 'ionicons/icons';
+import { home, cart, briefcase, mail, megaphone } from 'ionicons/icons';
 
 @Component({
   selector: 'app-tabs',
@@ -13,6 +13,6 @@ export class TabsPage {
   public environmentInjector = inject(EnvironmentInjector);
 
   constructor() {
-    addIcons({ home, search, briefcase, mail, person });
+    addIcons({ home, cart, briefcase, mail, megaphone });
   }
 }

--- a/gptgig/src/app/tabs/tabs.routes.ts
+++ b/gptgig/src/app/tabs/tabs.routes.ts
@@ -8,10 +8,10 @@ export const routes: Routes = [
     children: [
      
        { path: 'home', loadComponent: () => import('./pages/home/home.page').then(m => m.HomePage) },
-      { path: 'search', loadComponent: () => import('./pages/search/search.page').then(m => m.SearchPage) },
+      { path: 'cart', loadComponent: () => import('../cart/cart.page').then(m => m.CartPage) },
       { path: 'services', loadComponent: () => import('./pages/services/services.page').then(m => m.ServicesPage) },
       { path: 'inbox', loadComponent: () => import('./pages/inbox/inbox.page').then(m => m.InboxPage) },
-      { path: 'profile', loadComponent: () => import('./pages/profile/profile.page').then(m => m.ProfilePage) },
+      { path: 'social', loadComponent: () => import('./pages/profile/profile.page').then(m => m.ProfilePage) },
       { path: 'admin', loadComponent: () => import('./pages/admin/admin.page').then(m => m.AdminPage) },
       {
         path: '',


### PR DESCRIPTION
## Summary
- Replace search tab with a cart tab that loads cart items and shows a cart icon
- Rebrand profile tab to social, using a megaphone icon and updated title
- Import and register new tab icons

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*
- `npm run lint` *(fails: lint errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_b_68ae80423ca883318949656142900550