### PR TITLE
feat: add social feeds gallery

### DIFF
--- a/gptgig/src/app/app.routes.ts
+++ b/gptgig/src/app/app.routes.ts
@@ -18,6 +18,13 @@ export const routes: Routes = [
     loadComponent: () => import('./cart/cart.page').then((m) => m.CartPage),
   },
   {
+    path: 'social-feeds',
+    loadComponent: () =>
+      import('./social-feeds/social-feeds.page').then(
+        (m) => m.SocialFeedsPage,
+      ),
+  },
+  {
     path: 'item/:id',
     loadComponent: () =>
       import('./item-detail/item-detail.page').then((m) => m.ItemDetailPage),

--- a/gptgig/src/app/social-feeds/social-feeds.page.html
+++ b/gptgig/src/app/social-feeds/social-feeds.page.html
@@ -1,0 +1,33 @@
+<ion-header>
+  <ion-toolbar>
+    <ion-title>Social Feeds</ion-title>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content>
+  <ion-grid>
+    <ion-row>
+      <ion-col size="12" size-md="6" *ngFor="let platform of platforms">
+        <ion-card>
+          <ion-card-header>
+            <ion-card-title>
+              <ion-icon [name]="platform.icon"></ion-icon>
+              {{ platform.name }}
+            </ion-card-title>
+          </ion-card-header>
+          <ion-card-content>
+            <ng-container *ngIf="!platform.loggedIn">
+              <ion-button (click)="login(platform)">Login</ion-button>
+            </ng-container>
+            <ng-container *ngIf="platform.loggedIn">
+              <ion-button size="small" (click)="create(platform)">Create</ion-button>
+              <ion-button size="small" (click)="read(platform)">Read</ion-button>
+              <ion-button size="small" (click)="update(platform)">Update</ion-button>
+              <ion-button size="small" color="danger" (click)="delete(platform)">Delete</ion-button>
+            </ng-container>
+          </ion-card-content>
+        </ion-card>
+      </ion-col>
+    </ion-row>
+  </ion-grid>
+</ion-content>

--- a/gptgig/src/app/social-feeds/social-feeds.page.scss
+++ b/gptgig/src/app/social-feeds/social-feeds.page.scss
@@ -1,0 +1,5 @@
+ion-card-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}

--- a/gptgig/src/app/social-feeds/social-feeds.page.ts
+++ b/gptgig/src/app/social-feeds/social-feeds.page.ts
@@ -1,0 +1,48 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { IonicModule } from '@ionic/angular';
+
+interface SocialPlatform {
+  name: string;
+  icon: string;
+  loggedIn: boolean;
+}
+
+@Component({
+  selector: 'app-social-feeds',
+  standalone: true,
+  imports: [IonicModule, CommonModule],
+  templateUrl: './social-feeds.page.html',
+  styleUrls: ['./social-feeds.page.scss'],
+})
+export class SocialFeedsPage {
+  platforms: SocialPlatform[] = [
+    { name: 'Facebook', icon: 'logo-facebook', loggedIn: false },
+    { name: 'TikTok', icon: 'logo-tiktok', loggedIn: false },
+    { name: 'Instagram', icon: 'logo-instagram', loggedIn: false },
+    { name: 'Snapchat', icon: 'logo-snapchat', loggedIn: false },
+    { name: 'X', icon: 'logo-twitter', loggedIn: false },
+    { name: 'LinkedIn', icon: 'logo-linkedin', loggedIn: false },
+    { name: 'YouTube', icon: 'logo-youtube', loggedIn: false },
+  ];
+
+  login(platform: SocialPlatform): void {
+    platform.loggedIn = true;
+  }
+
+  create(platform: SocialPlatform): void {
+    console.log(`create on ${platform.name}`);
+  }
+
+  read(platform: SocialPlatform): void {
+    console.log(`read on ${platform.name}`);
+  }
+
+  update(platform: SocialPlatform): void {
+    console.log(`update on ${platform.name}`);
+  }
+
+  delete(platform: SocialPlatform): void {
+    console.log(`delete on ${platform.name}`);
+  }
+}


### PR DESCRIPTION
## Summary
- add route for new social feeds page
- show login and CRUD actions for Facebook, TikTok, Instagram, Snapchat, X, LinkedIn, and YouTube

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint` *(fails: Lint errors found in the listed files)*

------
https://chatgpt.com/codex/tasks/task_b_68ae90ac758c83319ae5b0dd935082cb