### PR TITLE
Display Not Available message for failed social feed services

### DIFF
--- a/gptgig/src/app/social-feeds/social-feeds.page.html
+++ b/gptgig/src/app/social-feeds/social-feeds.page.html
@@ -20,10 +20,15 @@
               <ion-button (click)="login(platform)">Login</ion-button>
             </ng-container>
             <ng-container *ngIf="platform.loggedIn">
-              <ion-button size="small" (click)="create(platform)">Create</ion-button>
-              <ion-button size="small" (click)="read(platform)">Read</ion-button>
-              <ion-button size="small" (click)="update(platform)">Update</ion-button>
-              <ion-button size="small" color="danger" (click)="delete(platform)">Delete</ion-button>
+              <ng-container *ngIf="platform.unavailable; else actions">
+                <p>Not available</p>
+              </ng-container>
+              <ng-template #actions>
+                <ion-button size="small" (click)="create(platform)">Create</ion-button>
+                <ion-button size="small" (click)="read(platform)">Read</ion-button>
+                <ion-button size="small" (click)="update(platform)">Update</ion-button>
+                <ion-button size="small" color="danger" (click)="delete(platform)">Delete</ion-button>
+              </ng-template>
             </ng-container>
           </ion-card-content>
         </ion-card>

--- a/gptgig/src/app/social-feeds/social-feeds.page.ts
+++ b/gptgig/src/app/social-feeds/social-feeds.page.ts
@@ -1,17 +1,19 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { IonicModule } from '@ionic/angular';
 
 interface SocialPlatform {
   name: string;
   icon: string;
   loggedIn: boolean;
+  unavailable?: boolean;
 }
 
 @Component({
   selector: 'app-social-feeds',
   standalone: true,
-  imports: [IonicModule, CommonModule],
+  imports: [IonicModule, CommonModule, HttpClientModule],
   templateUrl: './social-feeds.page.html',
   styleUrls: ['./social-feeds.page.scss'],
 })
@@ -26,8 +28,11 @@ export class SocialFeedsPage {
     { name: 'YouTube', icon: 'logo-youtube', loggedIn: false },
   ];
 
+  private http = inject(HttpClient);
+
   login(platform: SocialPlatform): void {
     platform.loggedIn = true;
+    platform.unavailable = false;
   }
 
   create(platform: SocialPlatform): void {
@@ -35,7 +40,17 @@ export class SocialFeedsPage {
   }
 
   read(platform: SocialPlatform): void {
-    console.log(`read on ${platform.name}`);
+    platform.unavailable = false;
+    this.http
+      .get(`/api/social-feeds/${platform.name.toLowerCase()}`)
+      .subscribe({
+        next: (data) => {
+          console.log(`read on ${platform.name}`, data);
+        },
+        error: () => {
+          platform.unavailable = true;
+        },
+      });
   }
 
   update(platform: SocialPlatform): void {


### PR DESCRIPTION
## Summary
- show 'Not available' when social feed service calls fail
- use HttpClient with error handling for social feed requests

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless --progress=false` *(fails: No binary for ChromeHeadless browser on your platform)*
- `npm run lint` *(fails: Lint errors found in the listed files)*

------
https://chatgpt.com/codex/tasks/task_b_68ae98ff62788331a5f2df05dc084d08