### PR TITLE
Add GitHub Actions workflow for Azure deployment

### DIFF
--- a/.github/workflows/azure-deploy.yml
+++ b/.github/workflows/azure-deploy.yml
@@ -1,0 +1,57 @@
+name: Deploy to Azure
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install frontend dependencies
+        working-directory: gptgig
+        run: npm ci
+
+      - name: Test frontend
+        working-directory: gptgig
+        run: npm test
+
+      - name: Build frontend
+        working-directory: gptgig
+        run: npm run build -- --configuration=production
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Build backend
+        working-directory: gptgigapi
+        run: |
+          dotnet restore
+          dotnet publish -c Release -o publish
+
+      - name: Deploy frontend to Azure Static Web Apps
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          action: upload
+          app_location: gptgig
+          output_location: dist/gptgig
+
+      - name: Deploy backend to Azure Web App
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: ${{ secrets.AZURE_WEBAPP_NAME }}
+          publish-profile: ${{ secrets.AZURE_WEBAPP_PUBLISH_PROFILE }}
+          package: gptgigapi/publish


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build Angular front end, publish .NET API, and deploy both to Azure

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_b_68ae996da66c83318b4bb2403057134f