### PR TITLE
Require authentication for app

### DIFF
--- a/gptgig/src/app/app.routes.ts
+++ b/gptgig/src/app/app.routes.ts
@@ -1,9 +1,11 @@
 import { Routes } from '@angular/router';
+import { authGuard } from './guards/auth.guard';
 
 export const routes: Routes = [
   {
     path: '',
     loadChildren: () => import('./tabs/tabs.routes').then((m) => m.routes),
+    canActivate: [authGuard],
   },
   {
     path: 'login',
@@ -16,6 +18,7 @@ export const routes: Routes = [
   {
     path: 'cart',
     loadComponent: () => import('./cart/cart.page').then((m) => m.CartPage),
+    canActivate: [authGuard],
   },
   {
     path: 'social-feeds',
@@ -23,10 +26,12 @@ export const routes: Routes = [
       import('./social-feeds/social-feeds.page').then(
         (m) => m.SocialFeedsPage,
       ),
+    canActivate: [authGuard],
   },
   {
     path: 'item/:id',
     loadComponent: () =>
       import('./item-detail/item-detail.page').then((m) => m.ItemDetailPage),
+    canActivate: [authGuard],
   },
 ];

--- a/gptgig/src/app/auth/login.page.ts
+++ b/gptgig/src/app/auth/login.page.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { IonContent, IonInput, IonButton } from '@ionic/angular/standalone';
 import { AuthService } from '../services/auth.service';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-login',
@@ -13,9 +14,12 @@ export class LoginPage {
   email = '';
   password = '';
 
-  constructor(private auth: AuthService) {}
+  constructor(private auth: AuthService, private router: Router) {}
 
   login() {
-    this.auth.login({ email: this.email, password: this.password }).subscribe();
+    this.auth.login({ email: this.email, password: this.password }).subscribe((res) => {
+      this.auth.saveToken(res.token);
+      this.router.navigateByUrl('/');
+    });
   }
 }

--- a/gptgig/src/app/guards/auth.guard.ts
+++ b/gptgig/src/app/guards/auth.guard.ts
@@ -1,0 +1,13 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+
+export const authGuard: CanActivateFn = (route, state) => {
+  const auth = inject(AuthService);
+  const router = inject(Router);
+  if (auth.isAuthenticated()) {
+    return true;
+  }
+  return router.createUrlTree(['/login']);
+};
+

--- a/gptgig/src/app/services/auth.interceptor.ts
+++ b/gptgig/src/app/services/auth.interceptor.ts
@@ -1,0 +1,12 @@
+import { inject } from '@angular/core';
+import { HttpInterceptorFn } from '@angular/common/http';
+import { AuthService } from './auth.service';
+
+export const authInterceptor: HttpInterceptorFn = (req, next) => {
+  const token = inject(AuthService).getToken();
+  if (token) {
+    req = req.clone({ setHeaders: { Authorization: `Bearer ${token}` } });
+  }
+  return next(req);
+};
+

--- a/gptgig/src/app/services/auth.service.ts
+++ b/gptgig/src/app/services/auth.service.ts
@@ -6,6 +6,7 @@ import { environment } from '../../environments/environment';
 @Injectable({ providedIn: 'root' })
 export class AuthService {
   private baseUrl = environment.apiUrl + '/auth';
+  private tokenKey = 'token';
 
   constructor(private http: HttpClient) {}
 
@@ -13,7 +14,23 @@ export class AuthService {
     return this.http.post(`${this.baseUrl}/register`, data);
   }
 
-  login(data: { email: string; password: string }): Observable<any> {
-    return this.http.post(`${this.baseUrl}/login`, data);
+  login(data: { email: string; password: string }): Observable<{ token: string }> {
+    return this.http.post<{ token: string }>(`${this.baseUrl}/login`, data);
+  }
+
+  saveToken(token: string): void {
+    localStorage.setItem(this.tokenKey, token);
+  }
+
+  getToken(): string | null {
+    return localStorage.getItem(this.tokenKey);
+  }
+
+  isAuthenticated(): boolean {
+    return !!this.getToken();
+  }
+
+  logout(): void {
+    localStorage.removeItem(this.tokenKey);
   }
 }

--- a/gptgig/src/main.ts
+++ b/gptgig/src/main.ts
@@ -1,10 +1,11 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { RouteReuseStrategy, provideRouter, withPreloading, PreloadAllModules } from '@angular/router';
 import { IonicRouteStrategy, provideIonicAngular } from '@ionic/angular/standalone';
-import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
 
 import { routes } from './app/app.routes';
 import { AppComponent } from './app/app.component';
+import { authInterceptor } from './app/services/auth.interceptor';
 import { register } from 'swiper/element/bundle';
 register();
 bootstrapApplication(AppComponent, {
@@ -12,7 +13,7 @@ bootstrapApplication(AppComponent, {
     { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },
     provideIonicAngular(),
     provideRouter(routes, withPreloading(PreloadAllModules)),
-    provideHttpClient(),
+    provideHttpClient(withInterceptors([authInterceptor])),
   ],
 });
 

--- a/gptgigapi/Controllers/AuthController.cs
+++ b/gptgigapi/Controllers/AuthController.cs
@@ -5,6 +5,7 @@ using Microsoft.IdentityModel.Tokens;
 using System.Security.Claims;
 using System.Text;
 using gptgigapi.Services;
+using Microsoft.AspNetCore.Authorization;
 
 namespace gptgigapi.Controllers
 {
@@ -26,6 +27,7 @@ namespace gptgigapi.Controllers
         }
 
         [HttpPost("register")]
+        [AllowAnonymous]
         public async Task<IActionResult> Register([FromBody] RegisterDto dto)
         {
             var user = new IdentityUser { UserName = dto.Email, Email = dto.Email, PhoneNumber = dto.PhoneNumber };
@@ -43,6 +45,7 @@ namespace gptgigapi.Controllers
         }
 
         [HttpPost("login")]
+        [AllowAnonymous]
         public async Task<IActionResult> Login([FromBody] LoginDto dto)
         {
             var user = await _userManager.FindByEmailAsync(dto.Email);

--- a/gptgigapi/Program.cs
+++ b/gptgigapi/Program.cs
@@ -118,6 +118,6 @@ app.UseCors("AllowClient");
 app.UseAuthentication();
 app.UseAuthorization();
 
-app.MapControllers();
+app.MapControllers().RequireAuthorization();
 
 app.Run();


### PR DESCRIPTION
## Summary
- enforce JWT authentication across API endpoints and allow anonymous access only for login and registration
- gate Angular routes behind an auth guard with token persistence and HTTP interceptor

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser)*
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_b_68ae9aaa26ac83318647b320fc493cbb