### PR TITLE
feat: display login error messages

### DIFF
--- a/gptgig/src/app/auth/login.page.html
+++ b/gptgig/src/app/auth/login.page.html
@@ -2,4 +2,5 @@
   <ion-input placeholder="Email" [(ngModel)]="email"></ion-input>
   <ion-input placeholder="Password" type="password" [(ngModel)]="password"></ion-input>
   <ion-button expand="block" (click)="login()">Login</ion-button>
+  <ion-text color="danger" *ngIf="errorMessage">{{ errorMessage }}</ion-text>
 </ion-content>

--- a/gptgig/src/app/auth/login.page.ts
+++ b/gptgig/src/app/auth/login.page.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { IonContent, IonInput, IonButton } from '@ionic/angular/standalone';
+import { IonContent, IonInput, IonButton, IonText } from '@ionic/angular/standalone';
 import { AuthService } from '../services/auth.service';
 import { Router } from '@angular/router';
 
@@ -8,18 +8,29 @@ import { Router } from '@angular/router';
   selector: 'app-login',
   templateUrl: 'login.page.html',
   standalone: true,
-  imports: [FormsModule, IonContent, IonInput, IonButton]
+  imports: [FormsModule, IonContent, IonInput, IonButton, IonText]
 })
 export class LoginPage {
   email = '';
   password = '';
+  errorMessage = '';
 
   constructor(private auth: AuthService, private router: Router) {}
 
   login() {
-    this.auth.login({ email: this.email, password: this.password }).subscribe((res) => {
-      this.auth.saveToken(res.token);
-      this.router.navigateByUrl('/');
+    this.auth.login({ email: this.email, password: this.password }).subscribe({
+      next: (res) => {
+        this.errorMessage = '';
+        this.auth.saveToken(res.token);
+        this.router.navigateByUrl('/');
+      },
+      error: (err) => {
+        if (err.status === 401) {
+          this.errorMessage = 'Invalid email or password';
+        } else {
+          this.errorMessage = 'Login failed. Please try again.';
+        }
+      },
     });
   }
 }


### PR DESCRIPTION
## Summary
- show login errors when credentials are invalid or login fails

## Testing
- `npm run lint` *(fails: Prefer using the inject() function over constructor parameter injection, etc.)*
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform.)*

------
https://chatgpt.com/codex/tasks/task_b_68aea5bc0fb88331943d8271e07e0c90