### PR TITLE
feat: add preview and card editing in admin mode

### DIFF
--- a/gptgig/src/app/tabs/pages/admin/admin.page.html
+++ b/gptgig/src/app/tabs/pages/admin/admin.page.html
@@ -46,16 +46,20 @@
           <ion-item>
             <ion-textarea formControlName="description" label="Description" labelPlacement="stacked"></ion-textarea>
           </ion-item>
-          <ion-item lines="none" *ngIf="!isMobile">
+          <ion-item lines="none">
+            <ion-thumbnail slot="start">
+              <img [src]="svcForm.value.imageUrl || 'assets/placeholder-rect.jpg'" />
+            </ion-thumbnail>
             <ion-label>Image</ion-label>
-            <input type="file" accept="image/*" (change)="handleFile($event, 'imageUrl')" />
-          </ion-item>
-          <ion-item lines="none" *ngIf="isMobile">
-            <ion-label>Image</ion-label>
-            <ion-button (click)="captureImage('imageUrl')">Take Photo</ion-button>
+            <ng-container *ngIf="!isMobile; else mobileImg">
+              <input type="file" accept="image/*" (change)="handleFile($event, 'imageUrl')" />
+            </ng-container>
+            <ng-template #mobileImg>
+              <ion-button (click)="captureImage('imageUrl')">Change Photo</ion-button>
+            </ng-template>
           </ion-item>
           <ion-button type="button" expand="block" (click)="goBack()">Back</ion-button>
-          <ion-button type="submit" expand="block">Save & Next</ion-button>
+          <ion-button type="submit" expand="block">{{ editingSvc ? 'Update' : 'Save & Next' }}</ion-button>
         </form>
       </ion-card-content>
     </ion-card>
@@ -75,35 +79,42 @@
           <ion-item>
             <ion-input type="number" formControlName="rating" label="Rating" labelPlacement="stacked"></ion-input>
           </ion-item>
-          <ion-item lines="none" *ngIf="!isMobile">
+          <ion-item lines="none">
+            <ion-thumbnail slot="start">
+              <img [src]="providerForm.value.avatarUrl || 'assets/placeholder-avatar.jpg'" />
+            </ion-thumbnail>
             <ion-label>Avatar</ion-label>
-            <input type="file" accept="image/*" (change)="handleFile($event, 'avatarUrl')" />
-          </ion-item>
-          <ion-item lines="none" *ngIf="isMobile">
-            <ion-label>Avatar</ion-label>
-            <ion-button (click)="captureImage('avatarUrl')">Take Photo</ion-button>
+            <ng-container *ngIf="!isMobile; else mobileAv">
+              <input type="file" accept="image/*" (change)="handleFile($event, 'avatarUrl')" />
+            </ng-container>
+            <ng-template #mobileAv>
+              <ion-button (click)="captureImage('avatarUrl')">Change Photo</ion-button>
+            </ng-template>
           </ion-item>
           <ion-button type="button" expand="block" (click)="goBack()">Back</ion-button>
-          <ion-button type="submit" expand="block">Save & Next</ion-button>
+          <ion-button type="submit" expand="block">{{ editingProv ? 'Update' : 'Save & Next' }}</ion-button>
         </form>
       </ion-card-content>
     </ion-card>
   </ng-container>
 
-  <!-- Step 4: Review current services -->
+  <!-- Step 4: Preview and edit -->
   <ng-container *ngIf="step === 4">
     <ion-card>
       <ion-card-header>
-        <ion-card-title>Current Services</ion-card-title>
+        <ion-card-title>Preview</ion-card-title>
       </ion-card-header>
       <ion-card-content>
-        <ion-item *ngFor="let s of (services$ | async)">
-          <ion-thumbnail slot="start"><img [src]="s.imageUrl || 'assets/placeholder-rect.jpg'"></ion-thumbnail>
-          <ion-label>
-            <div>{{s.title}}</div>
-            <small>{{s.price ? ('$'+s.price) : ''}}</small>
-          </ion-label>
-        </ion-item>
+        <h2>Services</h2>
+        <div *ngFor="let s of (services$ | async)" class="preview-item">
+          <app-menu-card-rect [item]="s"></app-menu-card-rect>
+          <ion-button size="small" (click)="editService(s)">Edit</ion-button>
+        </div>
+        <h2>Providers</h2>
+        <div *ngFor="let p of (providers$ | async)" class="preview-item">
+          <app-menu-card-circ [provider]="p"></app-menu-card-circ>
+          <ion-button size="small" (click)="editProvider(p)">Edit</ion-button>
+        </div>
         <ion-button expand="block" (click)="goBack()">Back</ion-button>
       </ion-card-content>
     </ion-card>

--- a/gptgig/src/app/tabs/pages/admin/admin.page.scss
+++ b/gptgig/src/app/tabs/pages/admin/admin.page.scss
@@ -1,0 +1,8 @@
+ion-content.admin {
+  .preview-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 12px;
+  }
+}

--- a/gptgig/src/app/tabs/pages/admin/admin.page.ts
+++ b/gptgig/src/app/tabs/pages/admin/admin.page.ts
@@ -4,8 +4,10 @@ import { CommonModule } from '@angular/common';
 import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
 import { CatalogService } from '../../../services/catalog.service';
 import { PhotoService } from '../../../services/photo.service';
-import { App } from '@capacitor/app';
 import { PageToolbarComponent } from '../../../components/page-toolbar/page-toolbar.component';
+import { MenuCardRectComponent } from '../../../components/menu-card-rect/menu-card-rect.component';
+import { MenuCardCircComponent } from '../../../components/menu-card-circ/menu-card-circ.component';
+import { ServiceItem, Provider } from '../../../models/catalog.models';
 
 
 // Lightweight UUID (optional): if you prefer, replace with Date.now().toString()
@@ -13,7 +15,14 @@ import { PageToolbarComponent } from '../../../components/page-toolbar/page-tool
 @Component({
   standalone: true,
   selector: 'app-admin',
-  imports: [IonicModule, CommonModule, ReactiveFormsModule, PageToolbarComponent],
+  imports: [
+    IonicModule,
+    CommonModule,
+    ReactiveFormsModule,
+    PageToolbarComponent,
+    MenuCardRectComponent,
+    MenuCardCircComponent,
+  ],
   templateUrl: './admin.page.html',
   styleUrls: ['./admin.page.scss']
 })
@@ -30,6 +39,8 @@ export class AdminPage {
   providers$  = this.catalog.providers$;
 
   step = 1;
+  editingSvc = false;
+  editingProv = false;
 
   catForm = this.fb.group({
     id: [''],
@@ -70,7 +81,12 @@ export class AdminPage {
     this.catalog.upsertService(val as any).subscribe(() => {
       this.svcForm.reset();
       this.toastMsg('Service saved');
-      this.goNext();
+      if (this.editingSvc) {
+        this.editingSvc = false;
+        this.step = 4;
+      } else {
+        this.goNext();
+      }
     });
   }
 
@@ -80,7 +96,12 @@ export class AdminPage {
     this.catalog.upsertProvider(val as any).subscribe(() => {
       this.providerForm.reset({ rating: 4.8 });
       this.toastMsg('Provider saved');
-      this.goNext();
+      if (this.editingProv) {
+        this.editingProv = false;
+        this.step = 4;
+      } else {
+        this.goNext();
+      }
     });
   }
 
@@ -98,7 +119,13 @@ export class AdminPage {
   }
 
   goBack() {
-    if (this.step > 1) this.step--;
+    if (this.editingSvc || this.editingProv) {
+      this.editingSvc = false;
+      this.editingProv = false;
+      this.step = 4;
+    } else if (this.step > 1) {
+      this.step--;
+    }
   }
 
   async captureImage(control: 'imageUrl' | 'avatarUrl') {
@@ -112,5 +139,17 @@ export class AdminPage {
   private async toastMsg(message: string) {
     const t = await this.toast.create({ message, duration: 1200, position: 'bottom' });
     await t.present();
+  }
+
+  editService(s: ServiceItem) {
+    this.svcForm.patchValue(s as any);
+    this.editingSvc = true;
+    this.step = 2;
+  }
+
+  editProvider(p: Provider) {
+    this.providerForm.patchValue(p as any);
+    this.editingProv = true;
+    this.step = 3;
   }
 }


### PR DESCRIPTION
## Summary
- add preview screen in admin section to display services and providers
- enable editing of existing cards with image updates
- show photo previews and change photo controls in admin forms

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_b_68aeadb117708331825aab50776ba129