### PR TITLE
Add sign-up option and favicon background to login

### DIFF
--- a/gptgig/src/app/auth/login.page.html
+++ b/gptgig/src/app/auth/login.page.html
@@ -1,6 +1,7 @@
-<ion-content class="ion-padding">
+<ion-content class="ion-padding login-background">
   <ion-input placeholder="Email" [(ngModel)]="email"></ion-input>
   <ion-input placeholder="Password" type="password" [(ngModel)]="password"></ion-input>
   <ion-button expand="block" (click)="login()">Login</ion-button>
+  <ion-button expand="block" fill="outline" (click)="goToRegister()">Sign Up</ion-button>
   <ion-text color="danger" *ngIf="errorMessage">{{ errorMessage }}</ion-text>
 </ion-content>

--- a/gptgig/src/app/auth/login.page.scss
+++ b/gptgig/src/app/auth/login.page.scss
@@ -1,0 +1,3 @@
+.login-background {
+  --background: url('assets/icon/favicon.png') no-repeat center center / cover;
+}

--- a/gptgig/src/app/auth/login.page.ts
+++ b/gptgig/src/app/auth/login.page.ts
@@ -7,6 +7,7 @@ import { Router } from '@angular/router';
 @Component({
   selector: 'app-login',
   templateUrl: 'login.page.html',
+  styleUrls: ['login.page.scss'],
   standalone: true,
   imports: [FormsModule, IonContent, IonInput, IonButton, IonText]
 })
@@ -32,5 +33,9 @@ export class LoginPage {
         }
       },
     });
+  }
+
+  goToRegister() {
+    this.router.navigateByUrl('/register');
   }
 }


### PR DESCRIPTION
## Summary
- add sign-up button linking to registration screen
- use favicon as login page background

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint` *(fails: @angular-eslint rules trigger errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_b_68aeadefa8e88331b8f008b5dd83b78e