### PR TITLE
fix: correct login background icon path

### DIFF
--- a/gptgig/src/app/auth/login.page.scss
+++ b/gptgig/src/app/auth/login.page.scss
@@ -1,3 +1,3 @@
 .login-background {
-  --background: url('assets/icon/favicon.png') no-repeat center center / cover;
+  --background: url('../../assets/icon/favicon.png') no-repeat center center / cover;
 }


### PR DESCRIPTION
## Summary
- fix login page background icon path to use correct relative assets reference

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless --no-progress` *(fails: No binary for ChromeHeadless)*
- `npm run lint` *(fails: lint errors found)*

------
https://chatgpt.com/codex/tasks/task_b_68aeb0424e1883318f067357190a099b