### PR TITLE
fix: import NgIf for login page

### DIFF
--- a/gptgig/src/app/auth/login.page.ts
+++ b/gptgig/src/app/auth/login.page.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
+import { NgIf } from '@angular/common';
 import { IonContent, IonInput, IonButton, IonText } from '@ionic/angular/standalone';
 import { AuthService } from '../services/auth.service';
 import { Router } from '@angular/router';
@@ -9,7 +10,7 @@ import { Router } from '@angular/router';
   templateUrl: 'login.page.html',
   styleUrls: ['login.page.scss'],
   standalone: true,
-  imports: [FormsModule, IonContent, IonInput, IonButton, IonText]
+  imports: [FormsModule, NgIf, IonContent, IonInput, IonButton, IonText]
 })
 export class LoginPage {
   email = '';


### PR DESCRIPTION
## Summary
- import Angular's NgIf in login page to enable conditional error message

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint` *(fails: 28 problems (27 errors, 1 warning))*

------
https://chatgpt.com/codex/tasks/task_b_68aeb1f99c3c83319afb8c4b18b65b36