### PR TITLE
Add GitHub Actions for mobile builds

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -1,0 +1,39 @@
+name: Build Android App
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        working-directory: gptgig
+        run: npm ci
+
+      - name: Build web assets
+        working-directory: gptgig
+        run: npm run build -- --configuration=production
+
+      - name: Sync Capacitor for Android
+        working-directory: gptgig
+        run: npx cap sync android
+
+      - name: Build Android release
+        working-directory: gptgig/android
+        run: ./gradlew assembleRelease
+
+      - name: Upload Android artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-release-apk
+          path: gptgig/android/app/build/outputs/apk/release/app-release.apk

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -1,0 +1,45 @@
+name: Build iOS App
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  ios:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        working-directory: gptgig
+        run: npm ci
+
+      - name: Build web assets
+        working-directory: gptgig
+        run: npm run build -- --configuration=production
+
+      - name: Sync Capacitor for iOS
+        working-directory: gptgig
+        run: npx cap sync ios
+
+      - name: Build iOS app
+        working-directory: gptgig/ios/App
+        run: xcodebuild -scheme App -configuration Release -sdk iphonesimulator -derivedDataPath build
+
+      - name: Package iOS app
+        working-directory: gptgig/ios/App/build/Build/Products/Release-iphonesimulator
+        run: |
+          mkdir Payload
+          cp -R App.app Payload/
+          zip -r App.ipa Payload
+      - name: Upload iOS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-release-ipa
+          path: gptgig/ios/App/build/Build/Products/Release-iphonesimulator/App.ipa


### PR DESCRIPTION
## Summary
- add workflow to build and upload Android release APK
- add workflow to build and package iOS app for simulator and upload artifact

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_b_68aeb2b4163c8331b1b87bcaddc33ac2