### PR TITLE
feat: add toolbar to cart tab

### DIFF
--- a/gptgig/src/app/cart/cart.page.html
+++ b/gptgig/src/app/cart/cart.page.html
@@ -1,8 +1,4 @@
-<ion-header>
-  <ion-toolbar>
-    <ion-title>Cart</ion-title>
-  </ion-toolbar>
-</ion-header>
+<app-page-toolbar title="Cart"></app-page-toolbar>
 
 <ion-content>
   <ng-container *ngIf="cart.selectedItem$ | async as item; else empty">

--- a/gptgig/src/app/cart/cart.page.ts
+++ b/gptgig/src/app/cart/cart.page.ts
@@ -3,11 +3,18 @@ import { CommonModule, CurrencyPipe } from '@angular/common';
 import { IonicModule } from '@ionic/angular';
 import { CartService } from '../services/cart.service';
 import { PaymentButtonComponent } from '../components/payment-button/payment-button.component';
+import { PageToolbarComponent } from '../components/page-toolbar/page-toolbar.component';
 
 @Component({
   selector: 'app-cart',
   standalone: true,
-  imports: [IonicModule, CommonModule, CurrencyPipe, PaymentButtonComponent],
+  imports: [
+    IonicModule,
+    CommonModule,
+    CurrencyPipe,
+    PaymentButtonComponent,
+    PageToolbarComponent,
+  ],
   templateUrl: './cart.page.html',
   styleUrls: ['./cart.page.scss'],
 })


### PR DESCRIPTION
## Summary
- add shared PageToolbar component to Cart page
- import PageToolbar in cart page module for consistent header

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_b_68aefe81490c83319434d6c9a2314aa4