### PR TITLE
Refactor admin page to side-nav with template persistence

### DIFF
--- a/gptgig/src/app/models/catalog.models.ts
+++ b/gptgig/src/app/models/catalog.models.ts
@@ -24,3 +24,9 @@ export interface Provider {
   tags?: string[];
   servicesOffered?: string[]; // service IDs
 }
+
+export interface CatalogTemplate {
+  categories: ServiceCategory[];
+  services: ServiceItem[];
+  providers: Provider[];
+}

--- a/gptgig/src/app/models/default-templates.ts
+++ b/gptgig/src/app/models/default-templates.ts
@@ -1,0 +1,48 @@
+import { CatalogTemplate } from './catalog.models';
+
+export const DEFAULT_TEMPLATES: Record<string, CatalogTemplate> = {
+  basic: {
+    categories: [
+      { id: 'cat-basic', name: 'General', icon: 'briefcase' }
+    ],
+    services: [
+      { id: 'svc-basic', title: 'Consultation', categoryId: 'cat-basic', price: 0 }
+    ],
+    providers: [
+      { id: 'pro-basic', name: 'Provider', rating: 4.8 }
+    ]
+  },
+  salon: {
+    categories: [
+      { id: 'cat-hair', name: 'Hair', icon: 'cut' }
+    ],
+    services: [
+      { id: 'svc-cut', title: 'Haircut', categoryId: 'cat-hair', price: 30 }
+    ],
+    providers: [
+      { id: 'pro-stylist', name: 'Stylist', rating: 4.9 }
+    ]
+  },
+  auto: {
+    categories: [
+      { id: 'cat-auto', name: 'Auto', icon: 'car' }
+    ],
+    services: [
+      { id: 'svc-oil', title: 'Oil Change', categoryId: 'cat-auto', price: 40 }
+    ],
+    providers: [
+      { id: 'pro-mechanic', name: 'Mechanic', rating: 4.7 }
+    ]
+  },
+  tutoring: {
+    categories: [
+      { id: 'cat-math', name: 'Math', icon: 'calculator' }
+    ],
+    services: [
+      { id: 'svc-algebra', title: 'Algebra Tutoring', categoryId: 'cat-math', price: 50 }
+    ],
+    providers: [
+      { id: 'pro-tutor', name: 'Tutor', rating: 5 }
+    ]
+  }
+};

--- a/gptgig/src/app/tabs/pages/admin/admin.page.html
+++ b/gptgig/src/app/tabs/pages/admin/admin.page.html
@@ -1,123 +1,156 @@
-<app-page-toolbar title="Admin"></app-page-toolbar>
+<ion-split-pane contentId="admin-content">
+  <ion-menu contentId="admin-content">
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Admin</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content>
+      <ion-list>
+        <ion-item button (click)="setSection('templates')">
+          Templates
+          <ion-note slot="end">{{ selectedTemplate || 'None' }}</ion-note>
+        </ion-item>
+        <ion-item button (click)="setSection('categories')">
+          Categories
+          <ion-note slot="end">{{ (categories$ | async)?.length || 0 }}</ion-note>
+        </ion-item>
+        <ion-item button (click)="setSection('services')">
+          Services
+          <ion-note slot="end">{{ (services$ | async)?.length || 0 }}</ion-note>
+        </ion-item>
+        <ion-item button (click)="setSection('providers')">
+          Providers
+          <ion-note slot="end">{{ (providers$ | async)?.length || 0 }}</ion-note>
+        </ion-item>
+        <ion-item button (click)="setSection('preview')">
+          Preview
+        </ion-item>
+      </ion-list>
+    </ion-content>
+  </ion-menu>
 
-<ion-content class="admin">
-  <!-- Step 1: Category setup -->
-  <ng-container *ngIf="step === 1">
-    <ion-card>
-      <ion-card-header>
-        <ion-card-title>Service Categories</ion-card-title>
-      </ion-card-header>
-      <ion-card-content>
-        <form [formGroup]="catForm" (ngSubmit)="onCatSubmit()">
-          <ion-item>
-            <ion-input formControlName="name" label="Name" labelPlacement="floating" required></ion-input>
-          </ion-item>
-          <ion-item>
-            <ion-input formControlName="icon" label="Icon (ionicon name)" labelPlacement="stacked"></ion-input>
-          </ion-item>
-          <ion-button type="submit" expand="block">Save & Next</ion-button>
-        </form>
-      </ion-card-content>
-    </ion-card>
-  </ng-container>
+  <ion-content id="admin-content" class="admin">
+    <ng-container [ngSwitch]="section">
+      <ng-container *ngSwitchCase="'templates'">
+        <ion-card *ngFor="let key of templateKeys" (click)="selectTemplate(key)" [class.selected]="selectedTemplate===key">
+          <ion-card-header>
+            <ion-card-title>{{ key | titlecase }}</ion-card-title>
+          </ion-card-header>
+        </ion-card>
+      </ng-container>
 
-  <!-- Step 2: Service setup -->
-  <ng-container *ngIf="step === 2">
-    <ion-card>
-      <ion-card-header>
-        <ion-card-title>Services (Rect Cards)</ion-card-title>
-      </ion-card-header>
-      <ion-card-content>
-        <form [formGroup]="svcForm" (ngSubmit)="onSvcSubmit()">
-          <ion-item>
-            <ion-input formControlName="title" label="Title" labelPlacement="floating" required></ion-input>
-          </ion-item>
-          <ion-item>
-            <ion-select formControlName="categoryId" label="Category" labelPlacement="stacked" interface="popover">
-              <ion-select-option *ngFor="let c of (categories$ | async)" [value]="c.id">{{c.name}}</ion-select-option>
-            </ion-select>
-          </ion-item>
-          <ion-item>
-            <ion-input type="number" formControlName="price" label="Price (USD)" labelPlacement="stacked"></ion-input>
-          </ion-item>
-          <ion-item>
-            <ion-input type="number" formControlName="durationMin" label="Duration (min)" labelPlacement="stacked"></ion-input>
-          </ion-item>
-          <ion-item>
-            <ion-textarea formControlName="description" label="Description" labelPlacement="stacked"></ion-textarea>
-          </ion-item>
-          <ion-item lines="none">
-            <ion-thumbnail slot="start">
-              <img [src]="svcForm.value.imageUrl || 'assets/placeholder-rect.jpg'" />
-            </ion-thumbnail>
-            <ion-label>Image</ion-label>
-            <ng-container *ngIf="!isMobile; else mobileImg">
-              <input type="file" accept="image/*" (change)="handleFile($event, 'imageUrl')" />
-            </ng-container>
-            <ng-template #mobileImg>
-              <ion-button (click)="captureImage('imageUrl')">Change Photo</ion-button>
-            </ng-template>
-          </ion-item>
-          <ion-button type="button" expand="block" (click)="goBack()">Back</ion-button>
-          <ion-button type="submit" expand="block">{{ editingSvc ? 'Update' : 'Save & Next' }}</ion-button>
-        </form>
-      </ion-card-content>
-    </ion-card>
-  </ng-container>
+      <ng-container *ngSwitchCase="'categories'">
+        <ion-card>
+          <ion-card-header>
+            <ion-card-title>Service Categories</ion-card-title>
+          </ion-card-header>
+          <ion-card-content>
+            <form [formGroup]="catForm" (ngSubmit)="onCatSubmit()">
+              <ion-item>
+                <ion-input formControlName="name" label="Name" labelPlacement="floating" required></ion-input>
+              </ion-item>
+              <ion-item>
+                <ion-input formControlName="icon" label="Icon (ionicon name)" labelPlacement="stacked"></ion-input>
+              </ion-item>
+              <ion-button type="submit" expand="block">Save</ion-button>
+            </form>
+          </ion-card-content>
+        </ion-card>
+      </ng-container>
 
-  <!-- Step 3: Provider setup -->
-  <ng-container *ngIf="step === 3">
-    <ion-card>
-      <ion-card-header>
-        <ion-card-title>Providers (Circular Cards)</ion-card-title>
-      </ion-card-header>
-      <ion-card-content>
-        <form [formGroup]="providerForm" (ngSubmit)="onProvSubmit()">
-          <ion-item>
-            <ion-input formControlName="name" label="Name" labelPlacement="floating" required></ion-input>
-          </ion-item>
-          <ion-item>
-            <ion-input type="number" formControlName="rating" label="Rating" labelPlacement="stacked"></ion-input>
-          </ion-item>
-          <ion-item lines="none">
-            <ion-thumbnail slot="start">
-              <img [src]="providerForm.value.avatarUrl || 'assets/placeholder-avatar.jpg'" />
-            </ion-thumbnail>
-            <ion-label>Avatar</ion-label>
-            <ng-container *ngIf="!isMobile; else mobileAv">
-              <input type="file" accept="image/*" (change)="handleFile($event, 'avatarUrl')" />
-            </ng-container>
-            <ng-template #mobileAv>
-              <ion-button (click)="captureImage('avatarUrl')">Change Photo</ion-button>
-            </ng-template>
-          </ion-item>
-          <ion-button type="button" expand="block" (click)="goBack()">Back</ion-button>
-          <ion-button type="submit" expand="block">{{ editingProv ? 'Update' : 'Save & Next' }}</ion-button>
-        </form>
-      </ion-card-content>
-    </ion-card>
-  </ng-container>
+      <ng-container *ngSwitchCase="'services'">
+        <ion-card>
+          <ion-card-header>
+            <ion-card-title>Services (Rect Cards)</ion-card-title>
+          </ion-card-header>
+          <ion-card-content>
+            <form [formGroup]="svcForm" (ngSubmit)="onSvcSubmit()">
+              <ion-item>
+                <ion-input formControlName="title" label="Title" labelPlacement="floating" required></ion-input>
+              </ion-item>
+              <ion-item>
+                <ion-select formControlName="categoryId" label="Category" labelPlacement="stacked" interface="popover">
+                  <ion-select-option *ngFor="let c of (categories$ | async)" [value]="c.id">{{c.name}}</ion-select-option>
+                </ion-select>
+              </ion-item>
+              <ion-item>
+                <ion-input type="number" formControlName="price" label="Price (USD)" labelPlacement="stacked"></ion-input>
+              </ion-item>
+              <ion-item>
+                <ion-input type="number" formControlName="durationMin" label="Duration (min)" labelPlacement="stacked"></ion-input>
+              </ion-item>
+              <ion-item>
+                <ion-textarea formControlName="description" label="Description" labelPlacement="stacked"></ion-textarea>
+              </ion-item>
+              <ion-item lines="none">
+                <ion-thumbnail slot="start">
+                  <img [src]="svcForm.value.imageUrl || 'assets/placeholder-rect.jpg'" />
+                </ion-thumbnail>
+                <ion-label>Image</ion-label>
+                <ng-container *ngIf="!isMobile; else mobileImg">
+                  <input type="file" accept="image/*" (change)="handleFile($event, 'imageUrl')" />
+                </ng-container>
+                <ng-template #mobileImg>
+                  <ion-button (click)="captureImage('imageUrl')">Change Photo</ion-button>
+                </ng-template>
+              </ion-item>
+              <ion-button type="submit" expand="block">{{ editingSvc ? 'Update' : 'Save' }}</ion-button>
+            </form>
+          </ion-card-content>
+        </ion-card>
+      </ng-container>
 
-  <!-- Step 4: Preview and edit -->
-  <ng-container *ngIf="step === 4">
-    <ion-card>
-      <ion-card-header>
-        <ion-card-title>Preview</ion-card-title>
-      </ion-card-header>
-      <ion-card-content>
-        <h2>Services</h2>
-        <div *ngFor="let s of (services$ | async)" class="preview-item">
-          <app-menu-card-rect [item]="s"></app-menu-card-rect>
-          <ion-button size="small" (click)="editService(s)">Edit</ion-button>
-        </div>
-        <h2>Providers</h2>
-        <div *ngFor="let p of (providers$ | async)" class="preview-item">
-          <app-menu-card-circ [provider]="p"></app-menu-card-circ>
-          <ion-button size="small" (click)="editProvider(p)">Edit</ion-button>
-        </div>
-        <ion-button expand="block" (click)="goBack()">Back</ion-button>
-      </ion-card-content>
-    </ion-card>
-  </ng-container>
-</ion-content>
+      <ng-container *ngSwitchCase="'providers'">
+        <ion-card>
+          <ion-card-header>
+            <ion-card-title>Providers (Circular Cards)</ion-card-title>
+          </ion-card-header>
+          <ion-card-content>
+            <form [formGroup]="providerForm" (ngSubmit)="onProvSubmit()">
+              <ion-item>
+                <ion-input formControlName="name" label="Name" labelPlacement="floating" required></ion-input>
+              </ion-item>
+              <ion-item>
+                <ion-input type="number" formControlName="rating" label="Rating" labelPlacement="stacked"></ion-input>
+              </ion-item>
+              <ion-item lines="none">
+                <ion-thumbnail slot="start">
+                  <img [src]="providerForm.value.avatarUrl || 'assets/placeholder-avatar.jpg'" />
+                </ion-thumbnail>
+                <ion-label>Avatar</ion-label>
+                <ng-container *ngIf="!isMobile; else mobileAv">
+                  <input type="file" accept="image/*" (change)="handleFile($event, 'avatarUrl')" />
+                </ng-container>
+                <ng-template #mobileAv>
+                  <ion-button (click)="captureImage('avatarUrl')">Change Photo</ion-button>
+                </ng-template>
+              </ion-item>
+              <ion-button type="submit" expand="block">{{ editingProv ? 'Update' : 'Save' }}</ion-button>
+            </form>
+          </ion-card-content>
+        </ion-card>
+      </ng-container>
 
+      <ng-container *ngSwitchCase="'preview'">
+        <ion-card>
+          <ion-card-header>
+            <ion-card-title>Preview</ion-card-title>
+          </ion-card-header>
+          <ion-card-content>
+            <h2>Services</h2>
+            <div *ngFor="let s of (services$ | async)" class="preview-item">
+              <app-menu-card-rect [item]="s"></app-menu-card-rect>
+              <ion-button size="small" (click)="editService(s)">Edit</ion-button>
+            </div>
+            <h2>Providers</h2>
+            <div *ngFor="let p of (providers$ | async)" class="preview-item">
+              <app-menu-card-circ [provider]="p"></app-menu-card-circ>
+              <ion-button size="small" (click)="editProvider(p)">Edit</ion-button>
+            </div>
+          </ion-card-content>
+        </ion-card>
+      </ng-container>
+    </ng-container>
+  </ion-content>
+</ion-split-pane>

--- a/gptgig/src/app/tabs/pages/admin/admin.page.scss
+++ b/gptgig/src/app/tabs/pages/admin/admin.page.scss
@@ -6,3 +6,7 @@ ion-content.admin {
     margin-bottom: 12px;
   }
 }
+
+ion-card.selected {
+  border: 2px solid var(--ion-color-primary);
+}

--- a/gptgig/src/app/tabs/pages/admin/admin.page.spec.ts
+++ b/gptgig/src/app/tabs/pages/admin/admin.page.spec.ts
@@ -6,6 +6,7 @@ describe('AdminPage', () => {
   let fixture: ComponentFixture<AdminPage>;
 
   beforeEach(() => {
+    localStorage.clear();
     fixture = TestBed.createComponent(AdminPage);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -15,7 +16,7 @@ describe('AdminPage', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should start at step 1', () => {
-    expect(component.step).toBe(1);
+  it('should start at templates section', () => {
+    expect(component.section).toBe('templates');
   });
 });


### PR DESCRIPTION
## Summary
- introduce catalog templates and default template definitions
- refactor admin page into side nav interface with persistent selections
- store catalog selections locally via CatalogService

## Testing
- `npm run lint` *(fails: lint errors in unrelated files)*
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_b_68af01cce240833180594149611b9e7e