### PR TITLE
feat: redirect unauthenticated users and show action toasts

### DIFF
--- a/gptgig/src/app/app.component.ts
+++ b/gptgig/src/app/app.component.ts
@@ -1,13 +1,34 @@
-import { Component } from '@angular/core';
+import { Component, OnDestroy, OnInit, inject } from '@angular/core';
 import { IonApp, IonRouterOutlet } from '@ionic/angular/standalone';
+import { ToastService } from './services/toast.service';
 
 @Component({
   selector: 'app-root',
   templateUrl: 'app.component.html',
   imports: [IonApp, IonRouterOutlet],
 })
-export class AppComponent {
+export class AppComponent implements OnInit, OnDestroy {
+  private toast = inject(ToastService);
+
   constructor() {
      document.documentElement.classList.add('dark');
   }
+
+  ngOnInit() {
+    document.addEventListener('click', this.handleClick);
+  }
+
+  ngOnDestroy() {
+    document.removeEventListener('click', this.handleClick);
+  }
+
+  private handleClick = (ev: Event) => {
+    const target = (ev.target as HTMLElement).closest('button, a, ion-button');
+    if (target) {
+      const action = target.getAttribute('data-action') || target.textContent?.trim();
+      if (action) {
+        this.toast.show(`${action} clicked`);
+      }
+    }
+  };
 }

--- a/gptgig/src/app/guards/auth.guard.ts
+++ b/gptgig/src/app/guards/auth.guard.ts
@@ -1,13 +1,8 @@
 import { inject } from '@angular/core';
-import { CanActivateFn, Router } from '@angular/router';
+import { CanActivateFn } from '@angular/router';
 import { AuthService } from '../services/auth.service';
 
-export const authGuard: CanActivateFn = (route, state) => {
-  const auth = inject(AuthService);
-  const router = inject(Router);
-  if (auth.isAuthenticated()) {
-    return true;
-  }
-  return router.createUrlTree(['/login']);
+export const authGuard: CanActivateFn = () => {
+  return inject(AuthService).isAuthenticated();
 };
 

--- a/gptgig/src/app/services/auth.service.ts
+++ b/gptgig/src/app/services/auth.service.ts
@@ -1,5 +1,6 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { Router } from '@angular/router';
 import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
 
@@ -8,7 +9,8 @@ export class AuthService {
   private baseUrl = environment.apiUrl + '/auth';
   private tokenKey = 'token';
 
-  constructor(private http: HttpClient) {}
+  private http = inject(HttpClient);
+  private router = inject(Router);
 
   register(data: { email: string; password: string }): Observable<any> {
     return this.http.post(`${this.baseUrl}/register`, data);
@@ -27,7 +29,11 @@ export class AuthService {
   }
 
   isAuthenticated(): boolean {
-    return !!this.getToken();
+    const authed = !!this.getToken();
+    if (!authed) {
+      this.router.navigate(['/login']);
+    }
+    return authed;
   }
 
   logout(): void {

--- a/gptgig/src/app/services/toast.service.ts
+++ b/gptgig/src/app/services/toast.service.ts
@@ -1,0 +1,16 @@
+import { Injectable, inject } from '@angular/core';
+import { ToastController } from '@ionic/angular';
+
+@Injectable({ providedIn: 'root' })
+export class ToastService {
+  private toastCtrl = inject(ToastController);
+
+  async show(message: string) {
+    const t = await this.toastCtrl.create({
+      message,
+      duration: 1500,
+      position: 'bottom'
+    });
+    await t.present();
+  }
+}


### PR DESCRIPTION
## Summary
- redirect users to login when not authenticated
- simplify auth guard to rely on service redirect
- show toast messages on button clicks via new ToastService

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: stuck generating bundles, aborted)*
- `npm run lint` *(fails: 27 errors)*

------
https://chatgpt.com/codex/tasks/task_b_68af0c3defac83318de8cef58a61287f