### PR TITLE
Add templates and scheduling for service bookings

### DIFF
--- a/gptgig/src/app/cart/cart.page.html
+++ b/gptgig/src/app/cart/cart.page.html
@@ -22,6 +22,9 @@
           {{ item.price | currency:'USD':'symbol':'1.0-0' }}
         </ion-card-subtitle>
       </ion-card-header>
+      <ion-card-content *ngIf="item.selectedSlot">
+        <p>Scheduled at {{ item.selectedSlot }}</p>
+      </ion-card-content>
     </ion-card>
     <app-payment-button [amount]="(item.price || 0) * 100"></app-payment-button>
   </ng-container>

--- a/gptgig/src/app/item-detail/item-detail.page.html
+++ b/gptgig/src/app/item-detail/item-detail.page.html
@@ -13,6 +13,12 @@
     <div class="price" *ngIf="item.price">{{ item.price | currency:'USD':'symbol' }}</div>
     <div class="description" *ngIf="item.description">{{ item.description }}</div>
   </div>
+  <ion-item *ngIf="slots.length">
+    <ion-label>Time</ion-label>
+    <ion-select [(ngModel)]="selectedSlot">
+      <ion-select-option *ngFor="let s of slots" [value]="s">{{ s }}</ion-select-option>
+    </ion-select>
+  </ion-item>
   <ion-button expand="block" color="primary" (click)="addToCart()">Add to Cart</ion-button>
 </ion-content>
 

--- a/gptgig/src/app/item-detail/item-detail.page.spec.ts
+++ b/gptgig/src/app/item-detail/item-detail.page.spec.ts
@@ -6,6 +6,7 @@ import { BehaviorSubject } from 'rxjs';
 import { ItemDetailPage } from './item-detail.page';
 import { CatalogService } from '../services/catalog.service';
 import { CartService } from '../services/cart.service';
+import { SchedulerService } from '../services/scheduler.service';
 
 describe('ItemDetailPage', () => {
   let component: ItemDetailPage;
@@ -18,7 +19,8 @@ describe('ItemDetailPage', () => {
       providers: [
         { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => '1' } } } },
         { provide: CatalogService, useValue: { services$ } },
-        { provide: CartService, useValue: { selectItem: () => {} } }
+        { provide: CartService, useValue: { selectItem: () => {} } },
+        { provide: SchedulerService, useValue: { generateSlots: () => ['09:00'] } }
       ]
     }).compileComponents();
 

--- a/gptgig/src/app/item-detail/item-detail.page.ts
+++ b/gptgig/src/app/item-detail/item-detail.page.ts
@@ -1,37 +1,47 @@
 import { Component, OnInit, inject } from '@angular/core';
 import { IonicModule } from '@ionic/angular';
 import { CommonModule, CurrencyPipe } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { CatalogService } from '../services/catalog.service';
 import { CartService } from '../services/cart.service';
 import { ServiceItem } from '../models/catalog.models';
+import { SchedulerService } from '../services/scheduler.service';
 
 @Component({
   selector: 'app-item-detail',
   standalone: true,
-  imports: [IonicModule, CommonModule, CurrencyPipe],
+  imports: [IonicModule, CommonModule, CurrencyPipe, FormsModule],
   templateUrl: './item-detail.page.html',
   styleUrls: ['./item-detail.page.scss']
 })
 export class ItemDetailPage implements OnInit {
   item?: ServiceItem;
+  slots: string[] = [];
+  selectedSlot?: string;
 
   private route = inject(ActivatedRoute);
   private catalog = inject(CatalogService);
   private cart = inject(CartService);
   private router = inject(Router);
+  private scheduler = inject(SchedulerService);
 
   ngOnInit() {
     const id = this.route.snapshot.paramMap.get('id');
     if (id) {
       const items = this.catalog.services$.value;
       this.item = items.find((s) => s.id === id);
+      if (this.item) {
+        this.slots = this.item.availableSlots ?? this.scheduler.generateSlots();
+        this.selectedSlot = this.slots[0];
+      }
     }
   }
 
   addToCart() {
     if (this.item) {
-      this.cart.selectItem(this.item);
+      const item = { ...this.item, selectedSlot: this.selectedSlot };
+      this.cart.selectItem(item);
       this.router.navigate(['/cart']);
     }
   }

--- a/gptgig/src/app/models/catalog.models.ts
+++ b/gptgig/src/app/models/catalog.models.ts
@@ -14,6 +14,8 @@ export interface ServiceItem {
   tags?: string[];
   rating?: number;
   description?: string;
+  availableSlots?: string[];
+  selectedSlot?: string;
 }
 
 export interface Provider {

--- a/gptgig/src/app/models/default-templates.ts
+++ b/gptgig/src/app/models/default-templates.ts
@@ -44,5 +44,39 @@ export const DEFAULT_TEMPLATES: Record<string, CatalogTemplate> = {
     providers: [
       { id: 'pro-tutor', name: 'Tutor', rating: 5 }
     ]
+  },
+  homecook: {
+    categories: [
+      { id: 'cat-home', name: 'Home Cooking', icon: 'restaurant' }
+    ],
+    services: [
+      {
+        id: 'svc-meal',
+        title: 'Home-cooked Meal',
+        categoryId: 'cat-home',
+        price: 25,
+        availableSlots: ['17:00', '18:00', '19:00']
+      }
+    ],
+    providers: [
+      { id: 'pro-cook', name: 'Home Cook', rating: 4.8 }
+    ]
+  },
+  foodtruck: {
+    categories: [
+      { id: 'cat-truck', name: 'Food Truck', icon: 'bus' }
+    ],
+    services: [
+      {
+        id: 'svc-truck',
+        title: 'Food Truck Catering',
+        categoryId: 'cat-truck',
+        price: 300,
+        availableSlots: ['11:00', '13:00', '15:00']
+      }
+    ],
+    providers: [
+      { id: 'pro-truck', name: 'Food Truck', rating: 4.9 }
+    ]
   }
 };

--- a/gptgig/src/app/services/scheduler.service.ts
+++ b/gptgig/src/app/services/scheduler.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({ providedIn: 'root' })
+export class SchedulerService {
+  generateSlots(start = '09:00', end = '17:00', intervalMin = 60): string[] {
+    const slots: string[] = [];
+    const [sh, sm] = start.split(':').map(Number);
+    const [eh, em] = end.split(':').map(Number);
+    const current = new Date();
+    current.setHours(sh, sm, 0, 0);
+    const endDate = new Date();
+    endDate.setHours(eh, em, 0, 0);
+    while (current <= endDate) {
+      slots.push(current.toTimeString().slice(0,5));
+      current.setMinutes(current.getMinutes() + intervalMin);
+    }
+    return slots;
+  }
+}

--- a/gptgigapi/Data/CatalogData.cs
+++ b/gptgigapi/Data/CatalogData.cs
@@ -13,9 +13,9 @@ namespace gptgigapi.Data
 
         public static List<ServiceItem> Services { get; } = new()
         {
-            new ServiceItem { Id = "svc1", Title = "Apartment Deep Clean", CategoryId = "clean", Price = 149, DurationMin = 180, ImageUrl = "assets/samples/clean1.jpg", Rating = 4.9, Description = "Professional deep cleaning for your entire apartment." },
-            new ServiceItem { Id = "svc2", Title = "Two Movers & Truck", CategoryId = "move", Price = 95, DurationMin = 120, ImageUrl = "assets/samples/move1.jpg", Rating = 4.7, Description = "Reliable moving service with two helpers and a truck." },
-            new ServiceItem { Id = "svc3", Title = "Home Wi-Fi Tune Up", CategoryId = "tech", Price = 79, DurationMin = 60, ImageUrl = "assets/samples/tech1.jpg", Rating = 4.8, Description = "Optimize and secure your home wireless network." },
+            new ServiceItem { Id = "svc1", Title = "Apartment Deep Clean", CategoryId = "clean", Price = 149, DurationMin = 180, ImageUrl = "assets/samples/clean1.jpg", Rating = 4.9, Description = "Professional deep cleaning for your entire apartment.", AvailableSlots = new List<string>{ "09:00", "13:00" } },
+            new ServiceItem { Id = "svc2", Title = "Two Movers & Truck", CategoryId = "move", Price = 95, DurationMin = 120, ImageUrl = "assets/samples/move1.jpg", Rating = 4.7, Description = "Reliable moving service with two helpers and a truck.", AvailableSlots = new List<string>{ "10:00", "14:00" } },
+            new ServiceItem { Id = "svc3", Title = "Home Wi-Fi Tune Up", CategoryId = "tech", Price = 79, DurationMin = 60, ImageUrl = "assets/samples/tech1.jpg", Rating = 4.8, Description = "Optimize and secure your home wireless network.", AvailableSlots = new List<string>{ "11:00", "15:00" } },
         };
 
         public static List<Provider> Providers { get; } = new()

--- a/gptgigapi/Models/CatalogModels.cs
+++ b/gptgigapi/Models/CatalogModels.cs
@@ -18,6 +18,7 @@ namespace gptgigapi.Models
         public List<string>? Tags { get; set; }
         public double? Rating { get; set; }
         public string? Description { get; set; }
+        public List<string>? AvailableSlots { get; set; }
     }
 
     public class Provider


### PR DESCRIPTION
## Summary
- add "homecook" and "foodtruck" catalog templates
- extend service model with available slots and selected slot
- show a scheduler to pick a service time and display the booking in the cart

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless --progress=false` *(fails: missing Chrome)*
- `npm run lint` *(fails: lint errors in existing files)*
- `dotnet build gptgigapi`


------
https://chatgpt.com/codex/tasks/task_b_68af0214536c833185ec65d08cecfc55