### PR TITLE
feat: darken colors and bold icons

### DIFF
--- a/gptgig/src/global.scss
+++ b/gptgig/src/global.scss
@@ -35,3 +35,8 @@
 /* @import "@ionic/angular/css/palettes/dark.always.css"; */
 /* @import "@ionic/angular/css/palettes/dark.class.css"; */
 @import '@ionic/angular/css/palettes/dark.system.css';
+
+ion-icon {
+  font-weight: 700;
+  --ionicon-stroke-width: 48px;
+}

--- a/gptgig/src/theme/variables.scss
+++ b/gptgig/src/theme/variables.scss
@@ -2,47 +2,47 @@
 // http://ionicframework.com/docs/theming/
 :root {
   /* Brand */
-  --eagle-green: #004c54; /* Eagle Green (approx) */
-  --light-silver: #eeeeee;
+  --eagle-green: #004047; /* Eagle Green (approx) */
+  --light-silver: #cacaca;
 
   /* Ionic color slots */
   --ion-color-primary: var(--eagle-green);
-  --ion-color-primary-rgb: 0, 76, 84;
+  --ion-color-primary-rgb: 0, 64, 71;
   --ion-color-primary-contrast: #ffffff;
   --ion-color-primary-contrast-rgb: 255, 255, 255;
-  --ion-color-primary-shade: #003e45;
-  --ion-color-primary-tint: #1a6067;
+  --ion-color-primary-shade: #00343a;
+  --ion-color-primary-tint: #165157;
 
   --ion-color-secondary: var(--light-silver);
-  --ion-color-secondary-rgb: 238, 238, 238;
-  --ion-color-secondary-contrast: #0a0a0a;
-  --ion-color-secondary-contrast-rgb: 10, 10, 10;
-  --ion-color-secondary-shade: #d4d4d4;
-  --ion-color-secondary-tint: #f6f6f6;
+  --ion-color-secondary-rgb: 202, 202, 202;
+  --ion-color-secondary-contrast: #080808;
+  --ion-color-secondary-contrast-rgb: 8, 8, 8;
+  --ion-color-secondary-shade: #b4b4b4;
+  --ion-color-secondary-tint: #d1d1d1;
 
   /* Light defaults */
-  --ion-background-color: #ffffff;
-  --ion-text-color: #0d0f10;
-  --ion-color-step-50: #f3f4f4;
-  --ion-color-step-100: #e7e9ea;
-  --ion-color-step-150: #dcdedf;
-  --ion-color-step-200: #d0d3d5;
-  --ion-color-step-250: #c4c7ca;
-  --ion-color-step-300: #b8bcc0;
-  --ion-color-step-350: #adb1b6;
-  --ion-color-step-400: #a1a6ab;
-  --ion-color-step-450: #959aa1;
-  --ion-color-step-500: #898f97;
-  --ion-color-step-550: #7e848d;
-  --ion-color-step-600: #727982;
-  --ion-color-step-650: #666d78;
-  --ion-color-step-700: #5a626e;
-  --ion-color-step-750: #4f5764;
-  --ion-color-step-800: #434c59;
-  --ion-color-step-850: #37414f;
-  --ion-color-step-900: #2b3645;
-  --ion-color-step-950: #202b3b;
-  --ion-color-step-1000: #141f30;
+  --ion-background-color: #d8d8d8;
+  --ion-text-color: #0b0c0d;
+  --ion-color-step-50: #cecfcf;
+  --ion-color-step-100: #c4c6c6;
+  --ion-color-step-150: #bbbcbd;
+  --ion-color-step-200: #b0b3b5;
+  --ion-color-step-250: #a6a9ab;
+  --ion-color-step-300: #9c9fa3;
+  --ion-color-step-350: #93969a;
+  --ion-color-step-400: #888d91;
+  --ion-color-step-450: #7e8288;
+  --ion-color-step-500: #747980;
+  --ion-color-step-550: #6b7077;
+  --ion-color-step-600: #60666e;
+  --ion-color-step-650: #565c66;
+  --ion-color-step-700: #4c535d;
+  --ion-color-step-750: #434955;
+  --ion-color-step-800: #38404b;
+  --ion-color-step-850: #2e3743;
+  --ion-color-step-900: #242d3a;
+  --ion-color-step-950: #1b2432;
+  --ion-color-step-1000: #111a28;
 
   --radius-md: 12px;
   --radius-lg: 16px;
@@ -50,29 +50,29 @@
 
 /* Dark theme (default via .dark class on <html>) */
 :root.dark {
-  --ion-background-color: #121414;
-  --ion-text-color: #f5f7f7;
-  --ion-color-step-50: #181a1a;
-  --ion-color-step-100: #1c1e1e;
-  --ion-color-step-150: #202222;
-  --ion-color-step-200: #242626;
-  --ion-color-step-250: #282a2a;
-  --ion-color-step-300: #2c2e2e;
-  --ion-color-step-350: #303232;
-  --ion-color-step-400: #333636;
-  --ion-color-step-450: #373a3a;
-  --ion-color-step-500: #3b3e3e;
-  --ion-color-step-550: #3f4242;
-  --ion-color-step-600: #434646;
-  --ion-color-step-650: #474a4a;
-  --ion-color-step-700: #4b4e4e;
-  --ion-color-step-750: #4f5252;
-  --ion-color-step-800: #535656;
-  --ion-color-step-850: #575a5a;
-  --ion-color-step-900: #5b5e5e;
-  --ion-color-step-950: #5f6262;
-  --ion-color-step-1000: #0e1111;
+  --ion-background-color: #0f1111;
+  --ion-text-color: #d0d1d1;
+  --ion-color-step-50: #141616;
+  --ion-color-step-100: #171919;
+  --ion-color-step-150: #1b1c1c;
+  --ion-color-step-200: #1e2020;
+  --ion-color-step-250: #222323;
+  --ion-color-step-300: #252727;
+  --ion-color-step-350: #282a2a;
+  --ion-color-step-400: #2b2d2d;
+  --ion-color-step-450: #2e3131;
+  --ion-color-step-500: #323434;
+  --ion-color-step-550: #353838;
+  --ion-color-step-600: #383b3b;
+  --ion-color-step-650: #3c3e3e;
+  --ion-color-step-700: #3f4242;
+  --ion-color-step-750: #434545;
+  --ion-color-step-800: #464949;
+  --ion-color-step-850: #494c4c;
+  --ion-color-step-900: #4d4f4f;
+  --ion-color-step-950: #505353;
+  --ion-color-step-1000: #0b0e0e;
 
   /* Card surfaces in dark */
-  --card-surface: #1a1d1d;
+  --card-surface: #161818;
 }


### PR DESCRIPTION
## Summary
- deepen the app's color palette for better visibility
- thicken and bold Ionic icons for improved readability

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint` *(fails: lint errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_b_68af1cb905688331ab95b6ff927c25b8