### PR TITLE
fix appium pre-install script to update uiautomator2 driver

### DIFF
--- a/gptgig/package.json
+++ b/gptgig/package.json
@@ -10,7 +10,7 @@
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "lint": "ng lint",
-    "preappium": "appium driver install uiautomator2@4.2.9 || true",
+    "preappium": "appium driver install uiautomator2@4.2.9 || appium driver update uiautomator2",
     "appium": "wdio run wdio.appium.conf.js"
   },
   "private": true,


### PR DESCRIPTION
## Summary
- avoid Windows `'true'` error by updating `uiautomator2` driver when already installed

## Testing
- `npm test` *(fails: No binary for Chrome browser)*
- `npm run lint` *(fails: lint errors in existing code)*

------
https://chatgpt.com/codex/tasks/task_b_68af1e53aa94833182704f0faea25bcc