### PR TITLE
feat: add vendor order queue and spotify-style toolbar

### DIFF
--- a/gptgig/src/app/components/order-card/order-card.component.html
+++ b/gptgig/src/app/components/order-card/order-card.component.html
@@ -1,0 +1,10 @@
+<ion-card class="order-card">
+  <div
+    class="image"
+    [style.backgroundImage]="'url(' + (order.imageUrl || 'assets/placeholder-rect.jpg') + ')'">
+  </div>
+  <ion-card-header>
+    <ion-card-title>{{ order.title }}</ion-card-title>
+    <ion-card-subtitle>{{ order.customer }}</ion-card-subtitle>
+  </ion-card-header>
+</ion-card>

--- a/gptgig/src/app/components/order-card/order-card.component.scss
+++ b/gptgig/src/app/components/order-card/order-card.component.scss
@@ -1,0 +1,11 @@
+.order-card {
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+
+.image {
+  width: 100%;
+  padding-top: 100%;
+  background-size: cover;
+  background-position: center;
+}

--- a/gptgig/src/app/components/order-card/order-card.component.ts
+++ b/gptgig/src/app/components/order-card/order-card.component.ts
@@ -1,0 +1,15 @@
+import { Component, Input } from '@angular/core';
+import { IonicModule } from '@ionic/angular';
+import { CommonModule } from '@angular/common';
+import { Order } from '../../models/order';
+
+@Component({
+  standalone: true,
+  selector: 'app-order-card',
+  imports: [IonicModule, CommonModule],
+  templateUrl: './order-card.component.html',
+  styleUrls: ['./order-card.component.scss'],
+})
+export class OrderCardComponent {
+  @Input() order!: Order;
+}

--- a/gptgig/src/app/components/page-toolbar/page-toolbar.component.html
+++ b/gptgig/src/app/components/page-toolbar/page-toolbar.component.html
@@ -1,10 +1,13 @@
 <ion-header [translucent]="true">
   <ion-toolbar>
-    <app-search (search)="onSearch($event)"></app-search>
-    <ion-buttons slot="end">
+    <ion-buttons slot="start">
+      <ion-button routerLink="/tabs/home">
+        <ion-icon name="home"></ion-icon>
+      </ion-button>
       <ion-avatar (click)="openProfileModal()">
         <img [src]="avatarSrc" alt="Profile" />
       </ion-avatar>
     </ion-buttons>
+    <app-search (search)="onSearch($event)"></app-search>
   </ion-toolbar>
 </ion-header>

--- a/gptgig/src/app/components/page-toolbar/page-toolbar.component.scss
+++ b/gptgig/src/app/components/page-toolbar/page-toolbar.component.scss
@@ -3,17 +3,13 @@ ion-toolbar {
   align-items: center;
 }
 
-ion-title {
-  flex: 0 0 auto;
-}
-
-.toolbar-search {
+app-search {
   flex: 1;
   display: flex;
   justify-content: center;
 }
 
-.toolbar-search ion-searchbar {
+app-search ion-searchbar {
   width: 100%;
   max-width: 400px;
 }
@@ -21,4 +17,5 @@ ion-title {
 ion-avatar {
   width: 32px;
   height: 32px;
+  margin-left: 8px;
 }

--- a/gptgig/src/app/components/page-toolbar/page-toolbar.component.ts
+++ b/gptgig/src/app/components/page-toolbar/page-toolbar.component.ts
@@ -1,6 +1,7 @@
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { IonicModule, ModalController } from '@ionic/angular';
 import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
 import { ProfileModalComponent } from '../profile-modal/profile-modal.component';
 import { SearchComponent } from '../search/search.component';
 import { SearchOptions } from '../../models/search-options';
@@ -8,7 +9,7 @@ import { SearchOptions } from '../../models/search-options';
 @Component({
   selector: 'app-page-toolbar',
   standalone: true,
-  imports: [IonicModule, CommonModule, SearchComponent],
+  imports: [IonicModule, CommonModule, SearchComponent, RouterLink],
   templateUrl: './page-toolbar.component.html',
   styleUrls: ['./page-toolbar.component.scss']
 })

--- a/gptgig/src/app/models/order.ts
+++ b/gptgig/src/app/models/order.ts
@@ -1,0 +1,7 @@
+export interface Order {
+  id: string;
+  title: string;
+  customer: string;
+  status: string;
+  imageUrl?: string;
+}

--- a/gptgig/src/app/services/order.service.ts
+++ b/gptgig/src/app/services/order.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@angular/core';
+import { Observable, of } from 'rxjs';
+import { Order } from '../models/order';
+
+@Injectable({ providedIn: 'root' })
+export class OrderService {
+  private orders: Order[] = [
+    {
+      id: '1',
+      title: 'Coffee Beans 1kg',
+      customer: 'Alice',
+      status: 'pending',
+      imageUrl: 'assets/placeholder-rect.jpg',
+    },
+    {
+      id: '2',
+      title: 'Espresso Machine',
+      customer: 'Bob',
+      status: 'pending',
+      imageUrl: 'assets/placeholder-rect.jpg',
+    },
+    {
+      id: '3',
+      title: 'Grinder',
+      customer: 'Carol',
+      status: 'pending',
+      imageUrl: 'assets/placeholder-rect.jpg',
+    },
+  ];
+
+  getVendorQueue(): Observable<Order[]> {
+    return of(this.orders);
+  }
+}

--- a/gptgig/src/app/tabs/pages/home/home.page.html
+++ b/gptgig/src/app/tabs/pages/home/home.page.html
@@ -2,6 +2,15 @@
 
 <ion-content [fullscreen]="true" class="home-content">
   <div class="gutter">
+   @let orders = (orders$ | async);
+@if (orders?.length) {
+  <div class="orders-grid">
+    @for (order of orders; track order.id) {
+      <app-order-card [order]="order"></app-order-card>
+    }
+  </div>
+}
+
    @let topPicks = (topPicks$ | async);
 @if (topPicks) {
   <app-offers-carousel title="Top picks for you" [cardType]="'rect'" [items]="topPicks"></app-offers-carousel>

--- a/gptgig/src/app/tabs/pages/home/home.page.scss
+++ b/gptgig/src/app/tabs/pages/home/home.page.scss
@@ -7,5 +7,13 @@
 }
 
 .home-content {
-  .gutter { padding: 8px 8px 24px; }
+  .gutter {
+    padding: 8px 8px 24px;
+
+    .orders-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+      gap: 16px;
+    }
+  }
 }

--- a/gptgig/src/app/tabs/pages/home/home.page.ts
+++ b/gptgig/src/app/tabs/pages/home/home.page.ts
@@ -1,22 +1,31 @@
-import { Component, computed, CUSTOM_ELEMENTS_SCHEMA, inject } from '@angular/core';
+import { Component, CUSTOM_ELEMENTS_SCHEMA, inject } from '@angular/core';
 import { IonicModule } from '@ionic/angular';
 import { CommonModule, AsyncPipe } from '@angular/common';
 import { OffersCarouselComponent } from '../../../components/offers-carousel/offers-carousel.component';
 import { CatalogService } from '../../../services/catalog.service';
+import { OrderService } from '../../../services/order.service';
 import { map } from 'rxjs/operators';
-import { RouterLink } from '@angular/router';
 import { PageToolbarComponent } from 'src/app/components/page-toolbar/page-toolbar.component';
+import { OrderCardComponent } from '../../../components/order-card/order-card.component';
 
 @Component({
   standalone: true,
   selector: 'app-home',
-  imports: [IonicModule, CommonModule, AsyncPipe, OffersCarouselComponent, PageToolbarComponent],
+  imports: [
+    IonicModule,
+    CommonModule,
+    AsyncPipe,
+    OffersCarouselComponent,
+    PageToolbarComponent,
+    OrderCardComponent,
+  ],
   templateUrl: './home.page.html',
   styleUrls: ['./home.page.scss'],
   schemas: [CUSTOM_ELEMENTS_SCHEMA]
 })
 export class HomePage {
   private catalog = inject(CatalogService);
+  private orders = inject(OrderService);
 
   services$  = this.catalog.services$;
   providers$ = this.catalog.providers$;
@@ -24,4 +33,5 @@ export class HomePage {
   topPicks$ = this.services$.pipe(map(list => list.slice(0, 10)));
   trending$ = this.services$.pipe(map(list => [...list].reverse()));
   topProviders$ = this.providers$.pipe(map(list => list.slice(0, 10)));
+  orders$ = this.orders.getVendorQueue();
 }


### PR DESCRIPTION
## Summary
- show vendor orders queue on home page as card grid
- restyle page toolbar with left-aligned avatar and home icon
- add order card component and service

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_b_68af239ee5e88331883428a1e91a25ed