### PR TITLE
refactor: adopt modern Angular control flow

### DIFF
--- a/gptgig/src/app/auth/login.page.html
+++ b/gptgig/src/app/auth/login.page.html
@@ -3,5 +3,7 @@
   <ion-input placeholder="Password" type="password" [(ngModel)]="password"></ion-input>
   <ion-button expand="block" (click)="login()">Login</ion-button>
   <ion-button expand="block" fill="outline" (click)="goToRegister()">Sign Up</ion-button>
-  <ion-text color="danger" *ngIf="errorMessage">{{ errorMessage }}</ion-text>
+  @if (errorMessage) {
+    <ion-text color="danger">{{ errorMessage }}</ion-text>
+  }
 </ion-content>

--- a/gptgig/src/app/auth/register.page.html
+++ b/gptgig/src/app/auth/register.page.html
@@ -3,7 +3,9 @@
 <ion-input placeholder="Password" type="password" [(ngModel)]="password"></ion-input>
 <ion-searchbar placeholder="Search vendors" [(ngModel)]="vendorQuery" (ionInput)="searchVendors()"></ion-searchbar>
 <ion-list>
-  <ion-item *ngFor="let v of vendors" (click)="selectVendor(v)">{{ v.name }}</ion-item>
+  @for (v of vendors; track v) {
+    <ion-item (click)="selectVendor(v)">{{ v.name }}</ion-item>
+  }
 </ion-list>
 <ion-button fill="clear" (click)="addVendor()">
   <ion-icon name="add-circle" slot="start"></ion-icon>

--- a/gptgig/src/app/cart/cart.page.html
+++ b/gptgig/src/app/cart/cart.page.html
@@ -1,7 +1,7 @@
 <app-page-toolbar title="Cart"></app-page-toolbar>
 
 <ion-content>
-  <ng-container *ngIf="cart.selectedItem$ | async as item; else empty">
+  @if (cart.selectedItem$ | async; as item) {
     <ion-card>
       <ion-button
         class="close-btn"
@@ -18,21 +18,24 @@
       ></div>
       <ion-card-header>
         <ion-card-title>{{ item.title }}</ion-card-title>
-        <ion-card-subtitle *ngIf="item.price != null">
-          {{ item.price | currency:'USD':'symbol':'1.0-0' }}
-        </ion-card-subtitle>
+        @if (item.price != null) {
+          <ion-card-subtitle>
+            {{ item.price | currency:'USD':'symbol':'1.0-0' }}
+          </ion-card-subtitle>
+        }
       </ion-card-header>
-      <ion-card-content *ngIf="item.selectedSlot">
-        <p>Scheduled at {{ item.selectedSlot }}</p>
-      </ion-card-content>
+      @if (item.selectedSlot) {
+        <ion-card-content>
+          <p>Scheduled at {{ item.selectedSlot }}</p>
+        </ion-card-content>
+      }
     </ion-card>
     <app-payment-button [amount]="(item.price || 0) * 100"></app-payment-button>
-  </ng-container>
-  <ng-template #empty>
+  } @else {
     <ion-list>
       <ion-item>
         <ion-label>Your cart is empty.</ion-label>
       </ion-item>
     </ion-list>
-  </ng-template>
+  }
 </ion-content>

--- a/gptgig/src/app/components/menu-card-circ/menu-card-circ.component.html
+++ b/gptgig/src/app/components/menu-card-circ/menu-card-circ.component.html
@@ -4,6 +4,8 @@
   </div>
   <div class="meta">
     <div class="name">{{ provider.name }}</div>
-    <div class="sub" *ngIf="provider.rating">★ {{ provider.rating | number:'1.1-1' }}</div>
+    @if (provider.rating) {
+      <div class="sub">★ {{ provider.rating | number:'1.1-1' }}</div>
+    }
   </div>
 </ion-card>

--- a/gptgig/src/app/components/menu-card-rect/menu-card-rect.component.html
+++ b/gptgig/src/app/components/menu-card-rect/menu-card-rect.component.html
@@ -2,9 +2,11 @@
   <div class="image" [style.backgroundImage]="'url(' + (item.imageUrl || 'assets/placeholder-rect.jpg') + ')'"></div>
   <ion-card-header>
     <ion-card-title>{{ item.title }}</ion-card-title>
-    <ion-card-subtitle *ngIf="item.price != null">
-      {{ item.price | currency:'USD':'symbol':'1.0-0' }}
-      <span *ngIf="item.durationMin"> • {{ item.durationMin }}m</span>
-    </ion-card-subtitle>
+    @if (item.price != null) {
+      <ion-card-subtitle>
+        {{ item.price | currency:'USD':'symbol':'1.0-0' }}
+        @if (item.durationMin) { <span> • {{ item.durationMin }}m</span> }
+      </ion-card-subtitle>
+    }
   </ion-card-header>
 </ion-card>

--- a/gptgig/src/app/components/offers-carousel/offers-carousel.component.html
+++ b/gptgig/src/app/components/offers-carousel/offers-carousel.component.html
@@ -11,9 +11,11 @@
     css-mode="true"
     style="display:block; width:100%;"
   >
-    <swiper-slide *ngFor="let it of items">
-      <ng-container [ngTemplateOutlet]="cardType === 'rect' ? rect : circ" [ngTemplateOutletContext]="{ $implicit: it }"></ng-container>
-    </swiper-slide>
+    @for (it of items; track it) {
+      <swiper-slide>
+        <ng-container [ngTemplateOutlet]="cardType === 'rect' ? rect : circ" [ngTemplateOutletContext]="{ $implicit: it }"></ng-container>
+      </swiper-slide>
+    }
   </swiper-container>
 
   <!-- Templates for the two card types -->

--- a/gptgig/src/app/components/offers-feed-modal/offers-feed-modal.component.html
+++ b/gptgig/src/app/components/offers-feed-modal/offers-feed-modal.component.html
@@ -9,10 +9,10 @@
 
 <ion-content>
   <div class="feed">
-    <ng-container *ngFor="let it of feedItems">
+    @for (it of feedItems; track it) {
       <ng-container [ngTemplateOutlet]="cardType === 'rect' ? rect : circ"
                     [ngTemplateOutletContext]="{ $implicit: it }"></ng-container>
-    </ng-container>
+    }
   </div>
   <ion-infinite-scroll (ionInfinite)="loadData($event)">
     <ion-infinite-scroll-content loadingSpinner="bubbles"></ion-infinite-scroll-content>

--- a/gptgig/src/app/components/search/search.component.html
+++ b/gptgig/src/app/components/search/search.component.html
@@ -1,15 +1,20 @@
 <div class="search-container">
   <ion-searchbar [value]="query" placeholder="Search" (ionInput)="onSearchChange($event)"></ion-searchbar>
-  <ion-list *ngIf="results.length" class="results-dropdown">
-    <ion-item button *ngFor="let r of results" (click)="selectResult(r)">
-      <ion-label>{{ r.title }}</ion-label>
-    </ion-item>
-  </ion-list>
+  @if (results.length) {
+    <ion-list class="results-dropdown">
+      @for (r of results; track r) {
+        <ion-item button (click)="selectResult(r)">
+          <ion-label>{{ r.title }}</ion-label>
+        </ion-item>
+      }
+    </ion-list>
+  }
   <ion-button fill="clear" (click)="toggleAdvanced()">
     <ion-icon name="options-outline"></ion-icon>
   </ion-button>
 </div>
-<div *ngIf="showAdvanced" class="advanced-options">
+@if (showAdvanced) {
+<div class="advanced-options">
   <ion-item>
     <ion-input type="number" placeholder="Min Price" [(ngModel)]="options.minPrice"></ion-input>
   </ion-item>
@@ -21,3 +26,4 @@
   </ion-item>
   <ion-button expand="block" (click)="emitSearch()">Apply Filters</ion-button>
 </div>
+}

--- a/gptgig/src/app/item-detail/item-detail.page.html
+++ b/gptgig/src/app/item-detail/item-detail.page.html
@@ -1,28 +1,40 @@
-<ion-header *ngIf="item">
-  <ion-toolbar>
-    <ion-title>{{ item.title }}</ion-title>
-  </ion-toolbar>
-</ion-header>
+@if (item) {
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>{{ item.title }}</ion-title>
+    </ion-toolbar>
+  </ion-header>
 
-<ion-content *ngIf="item" [fullscreen]="true">
-  <div class="image-wrapper">
-    <img [src]="item.imageUrl || 'assets/placeholder-rect.jpg'" alt="{{ item.title }}" />
-  </div>
-  <div class="info">
-    <h2>{{ item.title }}</h2>
-    <div class="price" *ngIf="item.price">{{ item.price | currency:'USD':'symbol' }}</div>
-    <div class="description" *ngIf="item.description">{{ item.description }}</div>
-  </div>
-  <ion-item *ngIf="slots.length">
-    <ion-label>Time</ion-label>
-    <ion-select [(ngModel)]="selectedSlot">
-      <ion-select-option *ngFor="let s of slots" [value]="s">{{ s }}</ion-select-option>
-    </ion-select>
-  </ion-item>
-  <ion-button expand="block" color="primary" (click)="addToCart()">Add to Cart</ion-button>
-</ion-content>
+  <ion-content [fullscreen]="true">
+    <div class="image-wrapper">
+      <img [src]="item.imageUrl || 'assets/placeholder-rect.jpg'" alt="{{ item.title }}" />
+    </div>
+    <div class="info">
+      <h2>{{ item.title }}</h2>
+      @if (item.price) {
+        <div class="price">{{ item.price | currency:'USD':'symbol' }}</div>
+      }
+      @if (item.description) {
+        <div class="description">{{ item.description }}</div>
+      }
+    </div>
+    @if (slots.length) {
+      <ion-item>
+        <ion-label>Time</ion-label>
+        <ion-select [(ngModel)]="selectedSlot">
+          @for (s of slots; track s) {
+            <ion-select-option [value]="s">{{ s }}</ion-select-option>
+          }
+        </ion-select>
+      </ion-item>
+    }
+    <ion-button expand="block" color="primary" (click)="addToCart()">Add to Cart</ion-button>
+  </ion-content>
+}
 
-<ion-content *ngIf="!item">
-  <p class="empty">Item not found.</p>
-</ion-content>
+@if (!item) {
+  <ion-content>
+    <p class="empty">Item not found.</p>
+  </ion-content>
+}
 

--- a/gptgig/src/app/social-feeds/social-feeds.page.html
+++ b/gptgig/src/app/social-feeds/social-feeds.page.html
@@ -7,32 +7,33 @@
 <ion-content>
   <ion-grid>
     <ion-row>
-      <ion-col size="12" size-md="6" *ngFor="let platform of platforms">
-        <ion-card>
-          <ion-card-header>
-            <ion-card-title>
-              <ion-icon [name]="platform.icon"></ion-icon>
-              {{ platform.name }}
-            </ion-card-title>
-          </ion-card-header>
-          <ion-card-content>
-            <ng-container *ngIf="!platform.loggedIn">
-              <ion-button (click)="login(platform)">Login</ion-button>
-            </ng-container>
-            <ng-container *ngIf="platform.loggedIn">
-              <ng-container *ngIf="platform.unavailable; else actions">
-                <p>Not available</p>
-              </ng-container>
-              <ng-template #actions>
-                <ion-button size="small" (click)="create(platform)">Create</ion-button>
-                <ion-button size="small" (click)="read(platform)">Read</ion-button>
-                <ion-button size="small" (click)="update(platform)">Update</ion-button>
-                <ion-button size="small" color="danger" (click)="delete(platform)">Delete</ion-button>
-              </ng-template>
-            </ng-container>
-          </ion-card-content>
-        </ion-card>
-      </ion-col>
+      @for (platform of platforms; track platform) {
+        <ion-col size="12" size-md="6">
+          <ion-card>
+            <ion-card-header>
+              <ion-card-title>
+                <ion-icon [name]="platform.icon"></ion-icon>
+                {{ platform.name }}
+              </ion-card-title>
+            </ion-card-header>
+            <ion-card-content>
+              @if (!platform.loggedIn) {
+                <ion-button (click)="login(platform)">Login</ion-button>
+              }
+              @if (platform.loggedIn) {
+                @if (platform.unavailable) {
+                  <p>Not available</p>
+                } @else {
+                  <ion-button size="small" (click)="create(platform)">Create</ion-button>
+                  <ion-button size="small" (click)="read(platform)">Read</ion-button>
+                  <ion-button size="small" (click)="update(platform)">Update</ion-button>
+                  <ion-button size="small" color="danger" (click)="delete(platform)">Delete</ion-button>
+                }
+              }
+            </ion-card-content>
+          </ion-card>
+        </ion-col>
+      }
     </ion-row>
   </ion-grid>
 </ion-content>

--- a/gptgig/src/app/tabs/pages/admin/admin.page.html
+++ b/gptgig/src/app/tabs/pages/admin/admin.page.html
@@ -31,16 +31,18 @@
   </ion-menu>
 
   <ion-content id="admin-content" class="admin">
-    <ng-container [ngSwitch]="section">
-      <ng-container *ngSwitchCase="'templates'">
-        <ion-card *ngFor="let key of templateKeys" (click)="selectTemplate(key)" [class.selected]="selectedTemplate===key">
-          <ion-card-header>
-            <ion-card-title>{{ key | titlecase }}</ion-card-title>
-          </ion-card-header>
-        </ion-card>
-      </ng-container>
+    @switch (section) {
+      @case ('templates') {
+        @for (key of templateKeys; track key) {
+          <ion-card (click)="selectTemplate(key)" [class.selected]="selectedTemplate===key">
+            <ion-card-header>
+              <ion-card-title>{{ key | titlecase }}</ion-card-title>
+            </ion-card-header>
+          </ion-card>
+        }
+      }
 
-      <ng-container *ngSwitchCase="'categories'">
+      @case ('categories') {
         <ion-card>
           <ion-card-header>
             <ion-card-title>Service Categories</ion-card-title>
@@ -57,9 +59,9 @@
             </form>
           </ion-card-content>
         </ion-card>
-      </ng-container>
+      }
 
-      <ng-container *ngSwitchCase="'services'">
+      @case ('services') {
         <ion-card>
           <ion-card-header>
             <ion-card-title>Services (Rect Cards)</ion-card-title>
@@ -71,7 +73,9 @@
               </ion-item>
               <ion-item>
                 <ion-select formControlName="categoryId" label="Category" labelPlacement="stacked" interface="popover">
-                  <ion-select-option *ngFor="let c of (categories$ | async)" [value]="c.id">{{c.name}}</ion-select-option>
+                  @for (c of (categories$ | async); track c.id) {
+                    <ion-select-option [value]="c.id">{{c.name}}</ion-select-option>
+                  }
                 </ion-select>
               </ion-item>
               <ion-item>
@@ -88,20 +92,19 @@
                   <img [src]="svcForm.value.imageUrl || 'assets/placeholder-rect.jpg'" />
                 </ion-thumbnail>
                 <ion-label>Image</ion-label>
-                <ng-container *ngIf="!isMobile; else mobileImg">
+                @if (!isMobile) {
                   <input type="file" accept="image/*" (change)="handleFile($event, 'imageUrl')" />
-                </ng-container>
-                <ng-template #mobileImg>
+                } @else {
                   <ion-button (click)="captureImage('imageUrl')">Change Photo</ion-button>
-                </ng-template>
+                }
               </ion-item>
               <ion-button type="submit" expand="block">{{ editingSvc ? 'Update' : 'Save' }}</ion-button>
             </form>
           </ion-card-content>
         </ion-card>
-      </ng-container>
+      }
 
-      <ng-container *ngSwitchCase="'providers'">
+      @case ('providers') {
         <ion-card>
           <ion-card-header>
             <ion-card-title>Providers (Circular Cards)</ion-card-title>
@@ -119,38 +122,41 @@
                   <img [src]="providerForm.value.avatarUrl || 'assets/placeholder-avatar.jpg'" />
                 </ion-thumbnail>
                 <ion-label>Avatar</ion-label>
-                <ng-container *ngIf="!isMobile; else mobileAv">
+                @if (!isMobile) {
                   <input type="file" accept="image/*" (change)="handleFile($event, 'avatarUrl')" />
-                </ng-container>
-                <ng-template #mobileAv>
+                } @else {
                   <ion-button (click)="captureImage('avatarUrl')">Change Photo</ion-button>
-                </ng-template>
+                }
               </ion-item>
               <ion-button type="submit" expand="block">{{ editingProv ? 'Update' : 'Save' }}</ion-button>
             </form>
           </ion-card-content>
         </ion-card>
-      </ng-container>
+      }
 
-      <ng-container *ngSwitchCase="'preview'">
+      @case ('preview') {
         <ion-card>
           <ion-card-header>
             <ion-card-title>Preview</ion-card-title>
           </ion-card-header>
           <ion-card-content>
             <h2>Services</h2>
-            <div *ngFor="let s of (services$ | async)" class="preview-item">
-              <app-menu-card-rect [item]="s"></app-menu-card-rect>
-              <ion-button size="small" (click)="editService(s)">Edit</ion-button>
-            </div>
+            @for (s of (services$ | async); track s.id) {
+              <div class="preview-item">
+                <app-menu-card-rect [item]="s"></app-menu-card-rect>
+                <ion-button size="small" (click)="editService(s)">Edit</ion-button>
+              </div>
+            }
             <h2>Providers</h2>
-            <div *ngFor="let p of (providers$ | async)" class="preview-item">
-              <app-menu-card-circ [provider]="p"></app-menu-card-circ>
-              <ion-button size="small" (click)="editProvider(p)">Edit</ion-button>
-            </div>
+            @for (p of (providers$ | async); track p.id) {
+              <div class="preview-item">
+                <app-menu-card-circ [provider]="p"></app-menu-card-circ>
+                <ion-button size="small" (click)="editProvider(p)">Edit</ion-button>
+              </div>
+            }
           </ion-card-content>
         </ion-card>
-      </ng-container>
-    </ng-container>
+      }
+    }
   </ion-content>
 </ion-split-pane>

--- a/gptgig/src/app/tabs/pages/inbox/inbox.page.html
+++ b/gptgig/src/app/tabs/pages/inbox/inbox.page.html
@@ -1,12 +1,17 @@
 <app-page-toolbar title="Inbox"></app-page-toolbar>
 
 <ion-content [fullscreen]="true">
-  <div *ngFor="let msg of messages" class="message" [class.own]="msg.senderId === currentUserId">
-    <div class="bubble">
-      <p>{{ msg.content }}</p>
-      <small>{{ msg.timestamp | date: 'shortTime' }} <span *ngIf="msg.senderId === currentUserId">{{ msg.isRead ? '✔✔' : '✔' }}</span></small>
+  @for (msg of messages; track msg) {
+    <div class="message" [class.own]="msg.senderId === currentUserId">
+      <div class="bubble">
+        <p>{{ msg.content }}</p>
+        <small>
+          {{ msg.timestamp | date: 'shortTime' }}
+          @if (msg.senderId === currentUserId) {<span>{{ msg.isRead ? '✔✔' : '✔' }}</span>}
+        </small>
+      </div>
     </div>
-  </div>
+  }
 </ion-content>
 
 <ion-footer>

--- a/gptgig/src/app/tabs/pages/search/search.page.html
+++ b/gptgig/src/app/tabs/pages/search/search.page.html
@@ -2,11 +2,15 @@
 
 <ion-content>
   <ion-list>
-    <ion-item *ngFor="let item of results">
-      <ion-label>
-        <h2>{{ item.title }}</h2>
-        <p *ngIf="item.price">Price: {{ item.price | currency }}</p>
-      </ion-label>
-    </ion-item>
+    @for (item of results; track item) {
+      <ion-item>
+        <ion-label>
+          <h2>{{ item.title }}</h2>
+          @if (item.price) {
+            <p>Price: {{ item.price | currency }}</p>
+          }
+        </ion-label>
+      </ion-item>
+    }
   </ion-list>
 </ion-content>


### PR DESCRIPTION
## Summary
- replace legacy *ngFor/*ngIf directives with modern @for and @if blocks throughout templates
- convert admin page to new @switch/@case syntax for cleaner control flow

## Testing
- `npm run lint` *(fails: Prefer using the inject() function over constructor parameter injection)*
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_b_68af2638aeb08331a9e818a846b071fa