### PR TITLE
feat: apply Pantone Peach Fuzz theme

### DIFF
--- a/gptgig/src/app/components/menu-card-circ/menu-card-circ.component.scss
+++ b/gptgig/src/app/components/menu-card-circ/menu-card-circ.component.scss
@@ -12,6 +12,9 @@
     border: 2px solid var(--ion-color-primary);
     img { width: 100%; height: 100%; object-fit: cover; }
   }
-  .name { font-size: 13px; }
+  .name {
+    font-size: 13px;
+    color: var(--ion-color-primary);
+  }
   .sub { font-size: 12px; color: var(--ion-color-medium); }
 }

--- a/gptgig/src/app/components/menu-card-rect/menu-card-rect.component.scss
+++ b/gptgig/src/app/components/menu-card-rect/menu-card-rect.component.scss
@@ -11,6 +11,10 @@
   ion-card-header {
     padding: 12px;
   }
-  ion-card-title { font-size: 14px; line-height: 1.25; }
+  ion-card-title {
+    font-size: 14px;
+    line-height: 1.25;
+    color: var(--ion-color-primary);
+  }
   ion-card-subtitle { color: var(--ion-color-medium); font-size: 12px; }
 }

--- a/gptgig/src/app/components/offers-feed-modal/offers-feed-modal.component.scss
+++ b/gptgig/src/app/components/offers-feed-modal/offers-feed-modal.component.scss
@@ -7,4 +7,5 @@ ion-content {
   flex-direction: column;
   gap: 1rem;
   padding: 1rem;
+  color: var(--ion-color-primary);
 }

--- a/gptgig/src/app/tabs/pages/admin/admin.page.scss
+++ b/gptgig/src/app/tabs/pages/admin/admin.page.scss
@@ -9,4 +9,5 @@ ion-content.admin {
 
 ion-card.selected {
   border: 2px solid var(--ion-color-primary);
+  color: var(--ion-color-primary);
 }

--- a/gptgig/src/app/tabs/tabs.page.scss
+++ b/gptgig/src/app/tabs/tabs.page.scss
@@ -3,6 +3,6 @@ ion-tab-bar {
   --background: var(--ion-color-step-1000, #0e1111);
   --color: var(--ion-color-medium);
   --color-selected: var(--ion-color-primary);
-  border-top: 0;
+  border-top: 2px solid var(--ion-color-primary);
   padding-bottom: env(safe-area-inset-bottom);
 }

--- a/gptgig/src/theme/variables.scss
+++ b/gptgig/src/theme/variables.scss
@@ -4,14 +4,16 @@
   /* Brand */
   --eagle-green: #004047; /* Eagle Green (approx) */
   --light-silver: #cacaca;
+  /* Pantone Color of the Year 2024 - Peach Fuzz */
+  --peach-fuzz: #ffbe98;
 
   /* Ionic color slots */
-  --ion-color-primary: var(--eagle-green);
-  --ion-color-primary-rgb: 0, 64, 71;
-  --ion-color-primary-contrast: #ffffff;
-  --ion-color-primary-contrast-rgb: 255, 255, 255;
-  --ion-color-primary-shade: #00343a;
-  --ion-color-primary-tint: #165157;
+  --ion-color-primary: var(--peach-fuzz);
+  --ion-color-primary-rgb: 255, 190, 152;
+  --ion-color-primary-contrast: #000000;
+  --ion-color-primary-contrast-rgb: 0, 0, 0;
+  --ion-color-primary-shade: #e5ab88;
+  --ion-color-primary-tint: #ffc4a2;
 
   --ion-color-secondary: var(--light-silver);
   --ion-color-secondary-rgb: 202, 202, 202;


### PR DESCRIPTION
## Summary
- integrate Pantone 2024 "Peach Fuzz" as new primary color
- highlight cards, tabs and modals with the updated color styling

## Testing
- `CHROME_BIN=chromium-browser npm test -- --browsers=ChromeHeadless --watch=false` *(fails: Command '/usr/bin/chromium-browser' requires the chromium snap to be installed)*
- `npm run lint` *(fails: lint errors in existing source)*

------
https://chatgpt.com/codex/tasks/task_b_68af2a733a888331981b625d054b22d8