### PR TITLE
Add profile CRUD API and frontend forms

### DIFF
--- a/gptgig/src/app/services/profile.service.ts
+++ b/gptgig/src/app/services/profile.service.ts
@@ -1,0 +1,31 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export interface Profile {
+  id: number;
+  displayName: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ProfileService {
+  private baseUrl = environment.apiUrl + '/profiles';
+  private http = inject(HttpClient);
+
+  getProfile(): Observable<Profile> {
+    return this.http.get<Profile>(this.baseUrl);
+  }
+
+  createProfile(data: { displayName: string }): Observable<Profile> {
+    return this.http.post<Profile>(this.baseUrl, data);
+  }
+
+  updateProfile(data: { displayName: string }): Observable<Profile> {
+    return this.http.put<Profile>(this.baseUrl, data);
+  }
+
+  deleteProfile(): Observable<void> {
+    return this.http.delete<void>(this.baseUrl);
+  }
+}

--- a/gptgig/src/app/tabs/pages/profile/profile.page.html
+++ b/gptgig/src/app/tabs/pages/profile/profile.page.html
@@ -1,9 +1,31 @@
-<app-page-toolbar title="Social"></app-page-toolbar>
+<app-page-toolbar title="Profile"></app-page-toolbar>
 
 <ion-content [fullscreen]="true">
   <ion-header collapse="condense">
     <ion-toolbar>
-      <ion-title size="large">social</ion-title>
+      <ion-title size="large">Profile</ion-title>
     </ion-toolbar>
   </ion-header>
+
+  <div class="ion-padding">
+    @if (profile) {
+      <h2>Welcome, {{ profile.displayName }}</h2>
+    }
+
+    <form (ngSubmit)="saveProfile()">
+      <ion-item>
+        <ion-label position="floating">Display Name</ion-label>
+        <ion-input [(ngModel)]="displayName" name="displayName"></ion-input>
+      </ion-item>
+      <ion-button type="submit" expand="full">
+        {{ profile ? 'Update' : 'Create' }} Profile
+      </ion-button>
+    </form>
+
+    @if (profile) {
+      <ion-button color="danger" expand="full" (click)="deleteProfile()">
+        Delete Profile
+      </ion-button>
+    }
+  </div>
 </ion-content>

--- a/gptgig/src/app/tabs/pages/profile/profile.page.spec.ts
+++ b/gptgig/src/app/tabs/pages/profile/profile.page.spec.ts
@@ -1,11 +1,24 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ProfilePage } from './profile.page';
+import { ProfileService } from 'src/app/services/profile.service';
+import { of } from 'rxjs';
+
+class MockProfileService {
+  getProfile() { return of(); }
+  createProfile(data: any) { return of({ id: 1, displayName: data.displayName }); }
+  updateProfile(data: any) { return of({ id: 1, displayName: data.displayName }); }
+  deleteProfile() { return of(void 0); }
+}
 
 describe('ProfilePage', () => {
   let component: ProfilePage;
   let fixture: ComponentFixture<ProfilePage>;
 
   beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ProfilePage],
+      providers: [{ provide: ProfileService, useClass: MockProfileService }]
+    });
     fixture = TestBed.createComponent(ProfilePage);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/gptgig/src/app/tabs/pages/profile/profile.page.ts
+++ b/gptgig/src/app/tabs/pages/profile/profile.page.ts
@@ -1,21 +1,53 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonContent, IonHeader, IonTitle, IonToolbar, IonItem, IonInput, IonButton, IonLabel } from '@ionic/angular/standalone';
 import { PageToolbarComponent } from 'src/app/components/page-toolbar/page-toolbar.component';
+import { Profile, ProfileService } from 'src/app/services/profile.service';
 
 @Component({
   selector: 'app-profile',
   templateUrl: './profile.page.html',
   styleUrls: ['./profile.page.scss'],
   standalone: true,
-  imports: [IonContent, IonHeader, IonTitle, IonToolbar, CommonModule, FormsModule, PageToolbarComponent]
+  imports: [IonContent, IonHeader, IonTitle, IonToolbar, IonItem, IonInput, IonButton, IonLabel, CommonModule, FormsModule, PageToolbarComponent]
 })
 export class ProfilePage implements OnInit {
+  profile: Profile | null = null;
+  displayName = '';
 
-  constructor() { }
+  constructor(private profileService: ProfileService) { }
 
   ngOnInit() {
+    this.loadProfile();
   }
 
+  loadProfile() {
+    this.profileService.getProfile().subscribe({
+      next: (res) => {
+        this.profile = res;
+        this.displayName = res.displayName;
+      },
+      error: () => {
+        this.profile = null;
+      }
+    });
+  }
+
+  saveProfile() {
+    const action = this.profile
+      ? this.profileService.updateProfile({ displayName: this.displayName })
+      : this.profileService.createProfile({ displayName: this.displayName });
+    action.subscribe((res) => {
+      this.profile = res;
+      this.displayName = res.displayName;
+    });
+  }
+
+  deleteProfile() {
+    this.profileService.deleteProfile().subscribe(() => {
+      this.profile = null;
+      this.displayName = '';
+    });
+  }
 }

--- a/gptgigapi/Controllers/ProfilesController.cs
+++ b/gptgigapi/Controllers/ProfilesController.cs
@@ -1,0 +1,90 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using gptgigapi.Data;
+using gptgigapi.Models;
+using System.Security.Claims;
+
+namespace gptgigapi.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    public class ProfilesController : ControllerBase
+    {
+        private readonly ApplicationDbContext _context;
+
+        public ProfilesController(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<CustomerProfile>> Get()
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userId == null)
+            {
+                return Unauthorized();
+            }
+            var profile = await _context.CustomerProfiles.FirstOrDefaultAsync(p => p.UserId == userId);
+            if (profile == null)
+            {
+                return NotFound();
+            }
+            return profile;
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<CustomerProfile>> Post([FromBody] ProfileDto dto)
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userId == null)
+            {
+                return Unauthorized();
+            }
+            var profile = new CustomerProfile { DisplayName = dto.DisplayName, UserId = userId };
+            _context.CustomerProfiles.Add(profile);
+            await _context.SaveChangesAsync();
+            return CreatedAtAction(nameof(Get), profile);
+        }
+
+        [HttpPut]
+        public async Task<ActionResult<CustomerProfile>> Put([FromBody] ProfileDto dto)
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userId == null)
+            {
+                return Unauthorized();
+            }
+            var profile = await _context.CustomerProfiles.FirstOrDefaultAsync(p => p.UserId == userId);
+            if (profile == null)
+            {
+                return NotFound();
+            }
+            profile.DisplayName = dto.DisplayName;
+            await _context.SaveChangesAsync();
+            return profile;
+        }
+
+        [HttpDelete]
+        public async Task<IActionResult> Delete()
+        {
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userId == null)
+            {
+                return Unauthorized();
+            }
+            var profile = await _context.CustomerProfiles.FirstOrDefaultAsync(p => p.UserId == userId);
+            if (profile == null)
+            {
+                return NotFound();
+            }
+            _context.CustomerProfiles.Remove(profile);
+            await _context.SaveChangesAsync();
+            return NoContent();
+        }
+    }
+
+    public record ProfileDto(string DisplayName);
+}


### PR DESCRIPTION
## Summary
- add server-side ProfilesController providing authenticated CRUD endpoints for customer profiles
- implement ProfileService and profile page forms to manage profile data and show user name
- replace deprecated `*ngIf` usage with Angular `@if` syntax

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser; set CHROME_BIN)*
- `dotnet build gptgigapi`


------
https://chatgpt.com/codex/tasks/task_b_68af376bd7008331870a90a74afa14ad