### PR TITLE
feat(home): add color-coded orders queue

### DIFF
--- a/gptgig/src/app/components/order-queue/order-queue.component.html
+++ b/gptgig/src/app/components/order-queue/order-queue.component.html
@@ -1,0 +1,19 @@
+<div class="orders-queue">
+  @if (orders?.length) {
+    <ion-list inset>
+      @for (order of orders; track order.id) {
+        <ion-item class="queue-item" [color]="getItemColor(order)" lines="none">
+          <ion-label>
+            <h3>{{ order.title }}</h3>
+            <p>{{ order.customer }}</p>
+          </ion-label>
+          <ion-badge slot="end" [color]="getItemColor(order)" class="time-badge">
+            {{ order.scheduledTime | date:'shortTime' }}
+          </ion-badge>
+        </ion-item>
+      }
+    </ion-list>
+  } @else {
+    <ion-text color="medium">No orders scheduled</ion-text>
+  }
+</div>

--- a/gptgig/src/app/components/order-queue/order-queue.component.scss
+++ b/gptgig/src/app/components/order-queue/order-queue.component.scss
@@ -1,0 +1,13 @@
+.orders-queue {
+  padding: 0.5rem;
+}
+
+.queue-item {
+  border-radius: 8px;
+  margin-bottom: 0.5rem;
+  --background: var(--ion-color-light);
+}
+
+.time-badge {
+  font-size: 0.75rem;
+}

--- a/gptgig/src/app/components/order-queue/order-queue.component.ts
+++ b/gptgig/src/app/components/order-queue/order-queue.component.ts
@@ -1,0 +1,29 @@
+import { Component, Input } from '@angular/core';
+import { IonicModule } from '@ionic/angular';
+import { CommonModule } from '@angular/common';
+import { Order } from '../../models/order';
+
+@Component({
+  standalone: true,
+  selector: 'app-order-queue',
+  imports: [IonicModule, CommonModule],
+  templateUrl: './order-queue.component.html',
+  styleUrls: ['./order-queue.component.scss']
+})
+export class OrderQueueComponent {
+  @Input() orders: Order[] | null = null;
+
+  getItemColor(order: Order): string {
+    const now = new Date();
+    const scheduled = new Date(order.scheduledTime);
+    const diff = scheduled.getTime() - now.getTime();
+
+    if (diff < 0) {
+      return 'danger';
+    }
+    if (diff < 60 * 60 * 1000) {
+      return 'warning';
+    }
+    return 'success';
+  }
+}

--- a/gptgig/src/app/models/order.ts
+++ b/gptgig/src/app/models/order.ts
@@ -4,4 +4,5 @@ export interface Order {
   customer: string;
   status: string;
   imageUrl?: string;
+  scheduledTime: string;
 }

--- a/gptgig/src/app/services/order.service.ts
+++ b/gptgig/src/app/services/order.service.ts
@@ -11,6 +11,7 @@ export class OrderService {
       customer: 'Alice',
       status: 'pending',
       imageUrl: 'assets/placeholder-rect.jpg',
+      scheduledTime: new Date(Date.now() + 30 * 60 * 1000).toISOString(),
     },
     {
       id: '2',
@@ -18,6 +19,7 @@ export class OrderService {
       customer: 'Bob',
       status: 'pending',
       imageUrl: 'assets/placeholder-rect.jpg',
+      scheduledTime: new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString(),
     },
     {
       id: '3',
@@ -25,6 +27,7 @@ export class OrderService {
       customer: 'Carol',
       status: 'pending',
       imageUrl: 'assets/placeholder-rect.jpg',
+      scheduledTime: new Date(Date.now() - 15 * 60 * 1000).toISOString(),
     },
   ];
 

--- a/gptgig/src/app/tabs/pages/home/home.page.html
+++ b/gptgig/src/app/tabs/pages/home/home.page.html
@@ -3,10 +3,12 @@
   <ion-menu contentId="main">
     <ion-header>
       <ion-toolbar color="tertiary">
-        <ion-title>Menu</ion-title>
+        <ion-title>Orders Queue</ion-title>
       </ion-toolbar>
     </ion-header>
-    <ion-content class="ion-padding"> Menu Content </ion-content>
+    <ion-content class="ion-padding">
+      <app-order-queue [orders]="orders$ | async"></app-order-queue>
+    </ion-content>
   </ion-menu>
 
   <div class="ion-page" id="main">

--- a/gptgig/src/app/tabs/pages/home/home.page.ts
+++ b/gptgig/src/app/tabs/pages/home/home.page.ts
@@ -7,6 +7,7 @@ import { OrderService } from '../../../services/order.service';
 import { map } from 'rxjs/operators';
 import { PageToolbarComponent } from 'src/app/components/page-toolbar/page-toolbar.component';
 import { OrderCardComponent } from '../../../components/order-card/order-card.component';
+import { OrderQueueComponent } from '../../../components/order-queue/order-queue.component';
 
 @Component({
   standalone: true,
@@ -18,6 +19,7 @@ import { OrderCardComponent } from '../../../components/order-card/order-card.co
     OffersCarouselComponent,
     PageToolbarComponent,
     OrderCardComponent,
+    OrderQueueComponent,
   ],
   templateUrl: './home.page.html',
   styleUrls: ['./home.page.scss'],


### PR DESCRIPTION
## Summary
- add Orders Queue component with color-coded items based on schedule
- display queue in Home tab side menu
- extend Order model and service with scheduled times

## Testing
- `npm run lint` *(fails: Prefer using the inject() function over constructor parameter injection)*
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_b_68b1c153160483318266049e95f04590