### PR TITLE
feat: add local config for client-side APIs

### DIFF
--- a/gptgig/angular.json
+++ b/gptgig/angular.json
@@ -67,6 +67,18 @@
               "sourceMap": true,
               "namedChunks": true
             },
+            "local": {
+              "optimization": false,
+              "extractLicenses": false,
+              "sourceMap": true,
+              "namedChunks": true,
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.local.ts"
+                }
+              ]
+            },
             "ci": {
               "progress": false
             }
@@ -81,6 +93,9 @@
             },
             "development": {
               "buildTarget": "app:build:development"
+            },
+            "local": {
+              "buildTarget": "app:build:local"
             },
             "ci": {
               "progress": false

--- a/gptgig/src/app/services/local-config.interceptor.ts
+++ b/gptgig/src/app/services/local-config.interceptor.ts
@@ -1,0 +1,89 @@
+import { HttpInterceptorFn, HttpResponse } from '@angular/common/http';
+import { of } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+export const localConfigInterceptor: HttpInterceptorFn = (req, next) => {
+  if (!environment.useLocalConfig || !environment.localConfig) {
+    return next(req);
+  }
+
+  const cfg = environment.localConfig;
+  const url = req.url;
+
+  // Profiles
+  if (url.endsWith('/profiles')) {
+    if (req.method === 'GET') {
+      return of(new HttpResponse({ status: 200, body: cfg.profiles }));
+    }
+    if (req.method === 'POST') {
+      const newProfile = { id: cfg.profiles.length + 1, ...req.body };
+      cfg.profiles.push(newProfile);
+      return of(new HttpResponse({ status: 200, body: newProfile }));
+    }
+    if (req.method === 'PUT') {
+      cfg.profiles[0] = { ...cfg.profiles[0], ...req.body };
+      return of(new HttpResponse({ status: 200, body: cfg.profiles[0] }));
+    }
+    if (req.method === 'DELETE') {
+      return of(new HttpResponse({ status: 200 }));
+    }
+  }
+
+  // Messages
+  if (url.includes('/messages')) {
+    if (req.method === 'GET') {
+      return of(new HttpResponse({ status: 200, body: cfg.messages }));
+    }
+    if (req.method === 'POST') {
+      const newMsg = {
+        id: cfg.messages.length + 1,
+        timestamp: new Date().toISOString(),
+        isRead: false,
+        ...req.body
+      };
+      cfg.messages.push(newMsg);
+      return of(new HttpResponse({ status: 200, body: newMsg }));
+    }
+    if (url.match(/\/read$/)) {
+      return of(new HttpResponse({ status: 200 }));
+    }
+  }
+
+  // Vendors
+  if (url.includes('/vendors')) {
+    return of(new HttpResponse({ status: 200, body: cfg.vendors }));
+  }
+
+  // Catalog
+  if (url.includes('/catalog/categories')) {
+    return of(new HttpResponse({ status: 200, body: cfg.categories }));
+  }
+  if (url.includes('/catalog/services')) {
+    return of(new HttpResponse({ status: 200, body: cfg.services }));
+  }
+  if (url.includes('/catalog/providers')) {
+    return of(new HttpResponse({ status: 200, body: cfg.providers }));
+  }
+
+  // Search
+  if (url.includes('/search')) {
+    return of(new HttpResponse({ status: 200, body: cfg.searchResults }));
+  }
+
+  // Payment intent
+  if (url.includes('/payments/create-intent')) {
+    return of(new HttpResponse({ status: 200, body: cfg.paymentIntent }));
+  }
+
+  // Auth
+  if (url.includes('/auth/login') || url.includes('/auth/register')) {
+    return of(new HttpResponse({ status: 200, body: { token: 'local-token' } }));
+  }
+
+  // Photos
+  if (url.includes('/photos') && req.method === 'POST') {
+    return of(new HttpResponse({ status: 200, body: { uploaded: true } }));
+  }
+
+  return next(req);
+};

--- a/gptgig/src/environments/environment.local.ts
+++ b/gptgig/src/environments/environment.local.ts
@@ -1,0 +1,9 @@
+import { localConfig } from './local-config';
+
+export const environment = {
+  production: false,
+  apiUrl: '',
+  stripePublishableKey: 'pk_test_your_key',
+  useLocalConfig: true,
+  localConfig
+};

--- a/gptgig/src/environments/environment.prod.ts
+++ b/gptgig/src/environments/environment.prod.ts
@@ -1,5 +1,7 @@
 export const environment = {
   production: true,
   apiUrl: 'https://localhost:5001/api',
-  stripePublishableKey: 'pk_live_your_key'
+  stripePublishableKey: 'pk_live_your_key',
+  useLocalConfig: false,
+  localConfig: null
 };

--- a/gptgig/src/environments/environment.ts
+++ b/gptgig/src/environments/environment.ts
@@ -1,5 +1,7 @@
 export const environment = {
   production: false,
   apiUrl: 'https://localhost:5001/api',
-  stripePublishableKey: 'pk_test_your_key'
+  stripePublishableKey: 'pk_test_your_key',
+  useLocalConfig: false,
+  localConfig: null
 };

--- a/gptgig/src/environments/local-config.ts
+++ b/gptgig/src/environments/local-config.ts
@@ -1,0 +1,53 @@
+/** Mock data used when running with the local-config option */
+export const localConfig = {
+  profiles: [
+    { id: 1, displayName: 'Alice' },
+    { id: 2, displayName: 'Bob' },
+    { id: 3, displayName: 'Charlie' },
+    { id: 4, displayName: 'Diana' },
+    { id: 5, displayName: 'Evan' }
+  ],
+  messages: [
+    { id: 1, senderId: '1', recipientId: '2', content: 'Hi Bob', timestamp: '2023-01-01T00:00:00Z', isRead: false },
+    { id: 2, senderId: '2', recipientId: '1', content: 'Hello Alice', timestamp: '2023-01-01T00:01:00Z', isRead: false },
+    { id: 3, senderId: '3', recipientId: '1', content: 'Hey there', timestamp: '2023-01-01T00:02:00Z', isRead: false },
+    { id: 4, senderId: '4', recipientId: '1', content: 'Good day', timestamp: '2023-01-01T00:03:00Z', isRead: false },
+    { id: 5, senderId: '5', recipientId: '1', content: 'Howdy', timestamp: '2023-01-01T00:04:00Z', isRead: false }
+  ],
+  vendors: [
+    { id: 1, name: 'Vendor One' },
+    { id: 2, name: 'Vendor Two' },
+    { id: 3, name: 'Vendor Three' },
+    { id: 4, name: 'Vendor Four' },
+    { id: 5, name: 'Vendor Five' }
+  ],
+  categories: [
+    { id: 'cat1', name: 'Category 1' },
+    { id: 'cat2', name: 'Category 2' },
+    { id: 'cat3', name: 'Category 3' },
+    { id: 'cat4', name: 'Category 4' },
+    { id: 'cat5', name: 'Category 5' }
+  ],
+  services: [
+    { id: 'svc1', title: 'Service 1', price: 10, categoryId: 'cat1' },
+    { id: 'svc2', title: 'Service 2', price: 20, categoryId: 'cat2' },
+    { id: 'svc3', title: 'Service 3', price: 30, categoryId: 'cat3' },
+    { id: 'svc4', title: 'Service 4', price: 40, categoryId: 'cat4' },
+    { id: 'svc5', title: 'Service 5', price: 50, categoryId: 'cat5' }
+  ],
+  providers: [
+    { id: 'prov1', name: 'Provider 1', servicesOffered: ['svc1'] },
+    { id: 'prov2', name: 'Provider 2', servicesOffered: ['svc2'] },
+    { id: 'prov3', name: 'Provider 3', servicesOffered: ['svc3'] },
+    { id: 'prov4', name: 'Provider 4', servicesOffered: ['svc4'] },
+    { id: 'prov5', name: 'Provider 5', servicesOffered: ['svc5'] }
+  ],
+  searchResults: [
+    { id: 'res1', title: 'Result 1', price: 15, categoryId: 'cat1' },
+    { id: 'res2', title: 'Result 2', price: 25, categoryId: 'cat2' },
+    { id: 'res3', title: 'Result 3', price: 35, categoryId: 'cat3' },
+    { id: 'res4', title: 'Result 4', price: 45, categoryId: 'cat4' },
+    { id: 'res5', title: 'Result 5', price: 55, categoryId: 'cat5' }
+  ],
+  paymentIntent: { clientSecret: 'local_secret_123' }
+};

--- a/gptgig/src/main.ts
+++ b/gptgig/src/main.ts
@@ -8,6 +8,7 @@ import { AppComponent } from './app/app.component';
 import { authInterceptor } from './app/services/auth.interceptor';
 import { offlineInterceptor } from './app/services/offline.interceptor';
 import { tenantInterceptor } from './app/services/tenant.interceptor';
+import { localConfigInterceptor } from './app/services/local-config.interceptor';
 import { register } from 'swiper/element/bundle';
 register();
 bootstrapApplication(AppComponent, {
@@ -15,7 +16,7 @@ bootstrapApplication(AppComponent, {
     { provide: RouteReuseStrategy, useClass: IonicRouteStrategy },
     provideIonicAngular(),
     provideRouter(routes, withPreloading(PreloadAllModules)),
-    provideHttpClient(withInterceptors([authInterceptor, offlineInterceptor, tenantInterceptor])),
+    provideHttpClient(withInterceptors([authInterceptor, offlineInterceptor, tenantInterceptor, localConfigInterceptor])),
   ],
 });
 


### PR DESCRIPTION
## Summary
- support optional local-config environment with mock data
- intercept HTTP calls to serve local data when enabled
- add Angular build/serve config for local use

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform. Please, set "CHROME_BIN" env variable.)*
- `npm run lint` *(fails: Prefer using the inject() function over constructor parameter injection and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_68b1d71181a08331851cc1cca6b9a305