### PR TITLE
feat: type local config

### DIFF
--- a/gptgig/src/app/services/local-config.interceptor.ts
+++ b/gptgig/src/app/services/local-config.interceptor.ts
@@ -1,13 +1,14 @@
 import { HttpInterceptorFn, HttpResponse } from '@angular/common/http';
 import { of } from 'rxjs';
 import { environment } from '../../environments/environment';
+import type { LocalConfig } from '../../environments/local-config';
 
 export const localConfigInterceptor: HttpInterceptorFn = (req, next) => {
   if (!environment.useLocalConfig || !environment.localConfig) {
     return next(req);
   }
 
-  const cfg = environment.localConfig;
+  const cfg: LocalConfig = environment.localConfig!;
   const url = req.url;
 
   // Profiles

--- a/gptgig/src/environments/environment.prod.ts
+++ b/gptgig/src/environments/environment.prod.ts
@@ -1,7 +1,9 @@
+import type { LocalConfig } from './local-config';
+
 export const environment = {
   production: true,
   apiUrl: 'https://localhost:5001/api',
   stripePublishableKey: 'pk_live_your_key',
   useLocalConfig: false,
-  localConfig: null
+  localConfig: null as LocalConfig | null
 };

--- a/gptgig/src/environments/environment.ts
+++ b/gptgig/src/environments/environment.ts
@@ -1,7 +1,9 @@
+import type { LocalConfig } from './local-config';
+
 export const environment = {
   production: false,
   apiUrl: 'https://localhost:5001/api',
   stripePublishableKey: 'pk_test_your_key',
   useLocalConfig: false,
-  localConfig: null
+  localConfig: null as LocalConfig | null
 };

--- a/gptgig/src/environments/local-config.ts
+++ b/gptgig/src/environments/local-config.ts
@@ -1,5 +1,17 @@
 /** Mock data used when running with the local-config option */
-export const localConfig = {
+
+export interface LocalConfig {
+  profiles: any[];
+  messages: any[];
+  vendors: any[];
+  categories: any[];
+  services: any[];
+  providers: any[];
+  searchResults: any[];
+  paymentIntent: any;
+}
+
+export const localConfig: LocalConfig = {
   profiles: [
     { id: 1, displayName: 'Alice' },
     { id: 2, displayName: 'Bob' },


### PR DESCRIPTION
## Summary
- define LocalConfig interface and apply to local config mock data
- type environment files to allow nullable LocalConfig
- update interceptor to use typed LocalConfig

## Testing
- `npm run lint` *(fails: sh: 1: ng: not found)*
- `npm test` *(fails: sh: 1: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b45c98059483319551179c2dc4c768