### PR TITLE
feat(profile): add avatar image capture

### DIFF
--- a/gptgig/src/app/services/profile.service.ts
+++ b/gptgig/src/app/services/profile.service.ts
@@ -6,6 +6,7 @@ import { environment } from '../../environments/environment';
 export interface Profile {
   id: number;
   displayName: string;
+  avatarUrl?: string;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -17,11 +18,11 @@ export class ProfileService {
     return this.http.get<Profile>(this.baseUrl);
   }
 
-  createProfile(data: { displayName: string }): Observable<Profile> {
+  createProfile(data: { displayName: string; avatarUrl?: string }): Observable<Profile> {
     return this.http.post<Profile>(this.baseUrl, data);
   }
 
-  updateProfile(data: { displayName: string }): Observable<Profile> {
+  updateProfile(data: { displayName?: string; avatarUrl?: string }): Observable<Profile> {
     return this.http.put<Profile>(this.baseUrl, data);
   }
 

--- a/gptgig/src/app/tabs/pages/profile/profile.page.html
+++ b/gptgig/src/app/tabs/pages/profile/profile.page.html
@@ -8,8 +8,23 @@
   </ion-header>
 
   <div class="ion-padding">
+    <ion-avatar class="ion-margin-bottom">
+      <img [src]="avatarUrl || 'https://ionicframework.com/docs/img/demos/avatar.svg'" />
+    </ion-avatar>
+
+    <ion-button expand="full" (click)="fileInput.click()">Upload Photo</ion-button>
+    <ion-button expand="full" (click)="capturePhoto()">Take Photo</ion-button>
+    <input type="file" accept="image/*" (change)="onFileSelected($event)" #fileInput hidden />
+
     @if (profile) {
-      <h2>Welcome, {{ profile.displayName }}</h2>
+      <ion-list>
+        <ion-item>
+          <ion-label>ID: {{ profile.id }}</ion-label>
+        </ion-item>
+        <ion-item>
+          <ion-label>Display Name: {{ profile.displayName }}</ion-label>
+        </ion-item>
+      </ion-list>
     }
 
     <form (ngSubmit)="saveProfile()">

--- a/gptgig/src/app/tabs/pages/profile/profile.page.spec.ts
+++ b/gptgig/src/app/tabs/pages/profile/profile.page.spec.ts
@@ -1,13 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ProfilePage } from './profile.page';
 import { ProfileService } from 'src/app/services/profile.service';
+import { PhotoService } from 'src/app/services/photo.service';
 import { of } from 'rxjs';
 
 class MockProfileService {
   getProfile() { return of(); }
-  createProfile(data: any) { return of({ id: 1, displayName: data.displayName }); }
-  updateProfile(data: any) { return of({ id: 1, displayName: data.displayName }); }
+  createProfile(data: any) { return of({ id: 1, displayName: data.displayName, avatarUrl: data.avatarUrl }); }
+  updateProfile(data: any) { return of({ id: 1, displayName: data.displayName, avatarUrl: data.avatarUrl }); }
   deleteProfile() { return of(void 0); }
+}
+
+class MockPhotoService {
+  captureBase64() { return Promise.resolve('data:image/png;base64,abc'); }
 }
 
 describe('ProfilePage', () => {
@@ -17,7 +22,10 @@ describe('ProfilePage', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [ProfilePage],
-      providers: [{ provide: ProfileService, useClass: MockProfileService }]
+      providers: [
+        { provide: ProfileService, useClass: MockProfileService },
+        { provide: PhotoService, useClass: MockPhotoService }
+      ]
     });
     fixture = TestBed.createComponent(ProfilePage);
     component = fixture.componentInstance;

--- a/gptgig/src/app/tabs/pages/profile/profile.page.ts
+++ b/gptgig/src/app/tabs/pages/profile/profile.page.ts
@@ -1,22 +1,24 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { IonContent, IonHeader, IonTitle, IonToolbar, IonItem, IonInput, IonButton, IonLabel } from '@ionic/angular/standalone';
+import { IonContent, IonHeader, IonTitle, IonToolbar, IonItem, IonInput, IonButton, IonLabel, IonAvatar, IonList } from '@ionic/angular/standalone';
 import { PageToolbarComponent } from 'src/app/components/page-toolbar/page-toolbar.component';
 import { Profile, ProfileService } from 'src/app/services/profile.service';
+import { PhotoService } from 'src/app/services/photo.service';
 
 @Component({
   selector: 'app-profile',
   templateUrl: './profile.page.html',
   styleUrls: ['./profile.page.scss'],
   standalone: true,
-  imports: [IonContent, IonHeader, IonTitle, IonToolbar, IonItem, IonInput, IonButton, IonLabel, CommonModule, FormsModule, PageToolbarComponent]
+  imports: [IonContent, IonHeader, IonTitle, IonToolbar, IonItem, IonInput, IonButton, IonLabel, IonAvatar, IonList, CommonModule, FormsModule, PageToolbarComponent]
 })
 export class ProfilePage implements OnInit {
   profile: Profile | null = null;
   displayName = '';
+  avatarUrl = '';
 
-  constructor(private profileService: ProfileService) { }
+  constructor(private profileService: ProfileService, private photoSvc: PhotoService) { }
 
   ngOnInit() {
     this.loadProfile();
@@ -27,6 +29,7 @@ export class ProfilePage implements OnInit {
       next: (res) => {
         this.profile = res;
         this.displayName = res.displayName;
+        this.avatarUrl = res.avatarUrl || '';
       },
       error: () => {
         this.profile = null;
@@ -36,11 +39,12 @@ export class ProfilePage implements OnInit {
 
   saveProfile() {
     const action = this.profile
-      ? this.profileService.updateProfile({ displayName: this.displayName })
-      : this.profileService.createProfile({ displayName: this.displayName });
+      ? this.profileService.updateProfile({ displayName: this.displayName, avatarUrl: this.avatarUrl })
+      : this.profileService.createProfile({ displayName: this.displayName, avatarUrl: this.avatarUrl });
     action.subscribe((res) => {
       this.profile = res;
       this.displayName = res.displayName;
+      this.avatarUrl = res.avatarUrl || '';
     });
   }
 
@@ -48,6 +52,25 @@ export class ProfilePage implements OnInit {
     this.profileService.deleteProfile().subscribe(() => {
       this.profile = null;
       this.displayName = '';
+      this.avatarUrl = '';
     });
+  }
+
+  async capturePhoto() {
+    const base64 = await this.photoSvc.captureBase64();
+    if (base64) {
+      this.avatarUrl = base64;
+    }
+  }
+
+  onFileSelected(event: Event) {
+    const input = event.target as HTMLInputElement;
+    if (!input.files || input.files.length === 0) return;
+    const file = input.files[0];
+    const reader = new FileReader();
+    reader.onload = () => {
+      this.avatarUrl = reader.result as string;
+    };
+    reader.readAsDataURL(file);
   }
 }

--- a/gptgig/src/environments/local-config.ts
+++ b/gptgig/src/environments/local-config.ts
@@ -13,11 +13,11 @@ export interface LocalConfig {
 
 export const localConfig: LocalConfig = {
   profiles: [
-    { id: 1, displayName: 'Alice' },
-    { id: 2, displayName: 'Bob' },
-    { id: 3, displayName: 'Charlie' },
-    { id: 4, displayName: 'Diana' },
-    { id: 5, displayName: 'Evan' }
+    { id: 1, displayName: 'Alice', avatarUrl: 'https://ionicframework.com/docs/img/demos/avatar.svg' },
+    { id: 2, displayName: 'Bob', avatarUrl: 'https://ionicframework.com/docs/img/demos/avatar.svg' },
+    { id: 3, displayName: 'Charlie', avatarUrl: 'https://ionicframework.com/docs/img/demos/avatar.svg' },
+    { id: 4, displayName: 'Diana', avatarUrl: 'https://ionicframework.com/docs/img/demos/avatar.svg' },
+    { id: 5, displayName: 'Evan', avatarUrl: 'https://ionicframework.com/docs/img/demos/avatar.svg' }
   ],
   messages: [
     { id: 1, senderId: '1', recipientId: '2', content: 'Hi Bob', timestamp: '2023-01-01T00:00:00Z', isRead: false },


### PR DESCRIPTION
## Summary
- allow profile avatars with display and upload
- add camera capture and file upload to profile page
- extend profile mocks with avatar URLs

## Testing
- `npm test` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b4d3376cc483318aa71ba08cce2a99