### PR TITLE
feat: show profile info in toolbar modal

### DIFF
--- a/gptgig/src/app/components/profile-modal/profile-modal.component.html
+++ b/gptgig/src/app/components/profile-modal/profile-modal.component.html
@@ -8,8 +8,23 @@
 </ion-header>
 
 <ion-content class="ion-padding">
-  <ion-list>
-    <ion-item button (click)="goToAdmin()">Admin</ion-item>
-  </ion-list>
-  <p>Your profile information goes here.</p>
+  @if (profile) {
+    <ion-avatar class="ion-margin-bottom">
+      <img [src]="profile.avatarUrl || 'assets/icon/favicon.png'" alt="Profile" />
+    </ion-avatar>
+    <ion-list>
+      <ion-item>
+        <ion-label>ID: {{ profile.id }}</ion-label>
+      </ion-item>
+      <ion-item>
+        <ion-label>Display Name: {{ profile.displayName }}</ion-label>
+      </ion-item>
+      <ion-item button (click)="goToAdmin()">Admin</ion-item>
+    </ion-list>
+  } @else {
+    <ion-list>
+      <ion-item button (click)="goToAdmin()">Admin</ion-item>
+    </ion-list>
+    <p>No profile information available.</p>
+  }
 </ion-content>

--- a/gptgig/src/app/components/profile-modal/profile-modal.component.spec.ts
+++ b/gptgig/src/app/components/profile-modal/profile-modal.component.spec.ts
@@ -2,6 +2,14 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ProfileModalComponent } from './profile-modal.component';
 import { IonicModule } from '@ionic/angular';
 import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
+import { ProfileService } from 'src/app/services/profile.service';
+
+class MockProfileService {
+  getProfile() {
+    return of({ id: 1, displayName: 'Test User' });
+  }
+}
 
 describe('ProfileModalComponent', () => {
   let component: ProfileModalComponent;
@@ -10,6 +18,7 @@ describe('ProfileModalComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ProfileModalComponent, IonicModule.forRoot(), RouterTestingModule],
+      providers: [{ provide: ProfileService, useClass: MockProfileService }]
     }).compileComponents();
 
     fixture = TestBed.createComponent(ProfileModalComponent);

--- a/gptgig/src/app/components/profile-modal/profile-modal.component.ts
+++ b/gptgig/src/app/components/profile-modal/profile-modal.component.ts
@@ -1,7 +1,8 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { IonicModule, ModalController } from '@ionic/angular';
 import { Router } from '@angular/router';
+import { Profile, ProfileService } from '../../services/profile.service';
 
 @Component({
   selector: 'app-profile-modal',
@@ -10,8 +11,25 @@ import { Router } from '@angular/router';
   templateUrl: './profile-modal.component.html',
   styleUrls: ['./profile-modal.component.scss'],
 })
-export class ProfileModalComponent {
-  constructor(private modalCtrl: ModalController, private router: Router) {}
+export class ProfileModalComponent implements OnInit {
+  profile: Profile | null = null;
+
+  constructor(
+    private modalCtrl: ModalController,
+    private router: Router,
+    private profileService: ProfileService
+  ) {}
+
+  ngOnInit() {
+    this.profileService.getProfile().subscribe({
+      next: (res) => {
+        this.profile = res;
+      },
+      error: () => {
+        this.profile = null;
+      }
+    });
+  }
 
   dismiss() {
     this.modalCtrl.dismiss();


### PR DESCRIPTION
## Summary
- load profile data into profile modal and display avatar, id, and display name
- add mock profile service to profile modal test

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint` *(fails: Prefer using the inject() function over constructor parameter injection)*

------
https://chatgpt.com/codex/tasks/task_b_68b4d690f5d483319e4c73500c5eb148