### PR TITLE
Refactor orders to support multiple items

### DIFF
--- a/gptgigapi/Data/ApplicationDbContext.cs
+++ b/gptgigapi/Data/ApplicationDbContext.cs
@@ -27,6 +27,7 @@ namespace gptgigapi.Data
         public DbSet<ServiceItem> ServiceItems => Set<ServiceItem>();
         public DbSet<Provider> Providers => Set<Provider>();
         public DbSet<Order> Orders => Set<Order>();
+        public DbSet<OrderItem> OrderItems => Set<OrderItem>();
 
         protected override void OnModelCreating(ModelBuilder builder)
         {
@@ -38,6 +39,7 @@ namespace gptgigapi.Data
             builder.Entity<Message>().HasQueryFilter(e => e.TenantId == _tenantId);
             builder.Entity<BusinessRegistration>().HasQueryFilter(e => e.TenantId == _tenantId);
             builder.Entity<Order>().HasQueryFilter(e => e.TenantId == _tenantId);
+            builder.Entity<OrderItem>().HasQueryFilter(e => e.TenantId == _tenantId);
 
             builder.Entity<ServiceItem>()
                 .Property(s => s.Price)
@@ -46,6 +48,12 @@ namespace gptgigapi.Data
             builder.Entity<Order>()
                 .Property(o => o.Amount)
                 .HasColumnType("decimal(18,2)");
+
+            builder.Entity<Order>()
+                .HasMany(o => o.Items)
+                .WithOne(i => i.Order)
+                .HasForeignKey(i => i.OrderId)
+                .OnDelete(DeleteBehavior.Cascade);
         }
 
         public override int SaveChanges()

--- a/gptgigapi/Data/DesignTimeDbContextFactory.cs
+++ b/gptgigapi/Data/DesignTimeDbContextFactory.cs
@@ -1,0 +1,23 @@
+using gptgigapi.Models;
+using gptgigapi.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+
+namespace gptgigapi.Data
+{
+    public class DesignTimeDbContextFactory : IDesignTimeDbContextFactory<ApplicationDbContext>
+    {
+        public ApplicationDbContext CreateDbContext(string[] args)
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<ApplicationDbContext>();
+            optionsBuilder.UseSqlServer("Server=(localdb)\\mssqllocaldb;Database=gptgigapi;Trusted_Connection=True;MultipleActiveResultSets=true");
+
+            return new ApplicationDbContext(optionsBuilder.Options, new StaticTenantProvider());
+        }
+
+        private class StaticTenantProvider : ITenantProvider
+        {
+            public string GetTenantId() => "default";
+        }
+    }
+}

--- a/gptgigapi/Migrations/20251127165533_AddOrderItems.Designer.cs
+++ b/gptgigapi/Migrations/20251127165533_AddOrderItems.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using gptgigapi.Data;
 
@@ -11,9 +12,11 @@ using gptgigapi.Data;
 namespace gptgigapi.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251127165533_AddOrderItems")]
+    partial class AddOrderItems
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/gptgigapi/Migrations/20251127165533_AddOrderItems.cs
+++ b/gptgigapi/Migrations/20251127165533_AddOrderItems.cs
@@ -1,0 +1,82 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace gptgigapi.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOrderItems : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ServiceImageUrl",
+                table: "Orders");
+
+            migrationBuilder.DropColumn(
+                name: "ServiceItemId",
+                table: "Orders");
+
+            migrationBuilder.DropColumn(
+                name: "ServiceTitle",
+                table: "Orders");
+
+            migrationBuilder.CreateTable(
+                name: "OrderItems",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    ServiceItemId = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ServiceTitle = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    ServiceImageUrl = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    Quantity = table.Column<int>(type: "int", nullable: false),
+                    OrderId = table.Column<int>(type: "int", nullable: false),
+                    TenantId = table.Column<string>(type: "nvarchar(max)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OrderItems", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_OrderItems_Orders_OrderId",
+                        column: x => x.OrderId,
+                        principalTable: "Orders",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OrderItems_OrderId",
+                table: "OrderItems",
+                column: "OrderId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "OrderItems");
+
+            migrationBuilder.AddColumn<string>(
+                name: "ServiceImageUrl",
+                table: "Orders",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ServiceItemId",
+                table: "Orders",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<string>(
+                name: "ServiceTitle",
+                table: "Orders",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+        }
+    }
+}

--- a/gptgigapi/Models/Order.cs
+++ b/gptgigapi/Models/Order.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
 namespace gptgigapi.Models
@@ -7,14 +8,6 @@ namespace gptgigapi.Models
     {
         [Key]
         public int Id { get; set; }
-
-        [Required]
-        public string ServiceItemId { get; set; } = string.Empty;
-
-        [Required]
-        public string ServiceTitle { get; set; } = string.Empty;
-
-        public string? ServiceImageUrl { get; set; }
 
         [Required]
         [Range(0, double.MaxValue)]
@@ -38,6 +31,8 @@ namespace gptgigapi.Models
         public string? ScheduledSlot { get; set; }
 
         public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+        public List<OrderItem> Items { get; set; } = new();
 
         public string TenantId { get; set; } = string.Empty;
     }

--- a/gptgigapi/Models/OrderItem.cs
+++ b/gptgigapi/Models/OrderItem.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace gptgigapi.Models
+{
+    public class OrderItem : ITenantEntity
+    {
+        [Key]
+        public int Id { get; set; }
+
+        [Required]
+        public string ServiceItemId { get; set; } = string.Empty;
+
+        [Required]
+        public string ServiceTitle { get; set; } = string.Empty;
+
+        public string? ServiceImageUrl { get; set; }
+
+        [Range(1, int.MaxValue)]
+        public int Quantity { get; set; } = 1;
+
+        [Required]
+        public int OrderId { get; set; }
+
+        public Order Order { get; set; } = null!;
+
+        public string TenantId { get; set; } = string.Empty;
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated order item entity and configure tenant-aware relationships
- update the orders API to accept collections of items and validate input
- create a migration to store order items and remove single-item columns

## Testing
- dotnet build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928814184e88332845dc96d555decfc)