### PR TITLE
Remove unused Ionic imports on services page

### DIFF
--- a/gptgig/src/app/tabs/pages/services/services.page.ts
+++ b/gptgig/src/app/tabs/pages/services/services.page.ts
@@ -1,7 +1,7 @@
 import { Component, inject } from '@angular/core';
 import { CommonModule, AsyncPipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { IonContent, IonHeader, IonTitle, IonToolbar } from '@ionic/angular/standalone';
+import { IonContent } from '@ionic/angular/standalone';
 import { PageToolbarComponent } from 'src/app/components/page-toolbar/page-toolbar.component';
 import { CatalogService } from '../../../services/catalog.service';
 import { map } from 'rxjs';
@@ -12,7 +12,7 @@ import { MenuCardRectComponent } from '../../../components/menu-card-rect/menu-c
   templateUrl: './services.page.html',
   styleUrls: ['./services.page.scss'],
   standalone: true,
-  imports: [IonContent, IonHeader, IonTitle, IonToolbar, CommonModule, FormsModule, PageToolbarComponent, AsyncPipe, MenuCardRectComponent]
+  imports: [IonContent, CommonModule, FormsModule, PageToolbarComponent, AsyncPipe, MenuCardRectComponent]
 })
 export class ServicesPage {
   private catalog = inject(CatalogService);


### PR DESCRIPTION
## Summary
- remove unused header, title, and toolbar Ionic imports from the services page component

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692894493a3483329dc64f197719867c)